### PR TITLE
Matching overlay 0x39 (ticktock hop)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,8 @@ build/src/2.0L/libc/string.c.o: OPTFLAGS = -O2
 build/src/2.0L/libc/xprintf.c.o: OPTFLAGS = -O2
 build/src/88CF0.c.o: OPTFLAGS = -O2
 build/src/88CF0.c.o: CFLAGS = -G0 -mips3 -mgp32 -mfp32 -D_LANGUAGE_C
+# Files that must have -Wa,--vr4300mul-off disabled:
+build/src/overlays/ovl_39_tick_tock_hop/%.c.o: CFLAGS = -G0 -mips3 -mgp32 -mfp32 -D_LANGUAGE_C
 
 # Compile .c files with kmc gcc (use strip to fix objects so that they can be linked with modern gnu ld) 
 $(BUILD_DIR)/src/%.c.o: src/%.c

--- a/include/functions.us.h
+++ b/include/functions.us.h
@@ -4,8 +4,10 @@
 #include "common.h"
 #include "game/object.h"
 
+#ifndef SKIP_SPR_DECL
 void SprAttrSet(s16, s16, u16);
 void SprAttrReset(s16, s16, u16);
+#endif
 s16 HuAudFXPlay(s32);
 void func_800E52F8_CD0C8_name_81(void);
 void func_800E5000_CCDD0_name_81(void);

--- a/marioparty3.yaml
+++ b/marioparty3.yaml
@@ -303,7 +303,7 @@ segments:
       - [0x81AD0, c, 2.0L/io/ai]
       - [0x81AF0, c, 2.0L/debug/kdebugserver]
       - [0x81DB0, c, 2.0L/debug/threadprofile]
-      - [0x81E40, asm] # TODO: supposedly 2.0L/gu/sqrtf, but it conflicts with 0x88710
+      - [0x81E40, hasm, 2.0L/gu/sqrtf]
       - [0x81E50, c, 2.0L/debug/readhost]
       - [0x81F20, c, 2.0L/os/initialize_isv]
       - [0x824C0, hasm, 2.0L/monutil]
@@ -355,7 +355,7 @@ segments:
       - [0x88440, c, libkmc/abs]
       - [0x88460, c, libkmc/fmod]
       - [0x88640, asm, libkmc/memset]
-      - [0x88710, hasm, 2.0L/gu/sqrtf]
+      - [0x88710, asm] # What is this? sqrtf is already defined in 0x81E40.
       - [0x88720, asm, libkmc/strcmp]
       - [0x88830, c, libkmc/strcpy]
       - [0x88900, hasm, libkmc/mmuldi3]
@@ -1439,9 +1439,10 @@ segments:
     subsegments:
       - [0x2BCE10, c]
       - [0x2C0E70, c]
-      - [0x2C5910, data, 2BCE10] #8010E4A0
-      - [0x2C5B10, .rodata, 2BCE10] #8010E6A0
-      - [0x2C5B10, .rodata, 2C0E70] #80112700
+      - [0x2C5910, .data, 2BCE10] #8010E4A0
+      - [0x2C5920, .data, 2C0E70] #8010E4B0
+      - [0x2C5A60, .rodata, 2BCE10] #8010E6A0
+      - [0x2C5B10, .rodata, 2C0E70] #8010E750
       - {0x2C5B50, type: bss, vram: 0x8010E6E0, name: ovl_39_bss}
 
   - type: code

--- a/src/overlays/ovl_39_tick_tock_hop/2BCE10.c
+++ b/src/overlays/ovl_39_tick_tock_hop/2BCE10.c
@@ -1,79 +1,1299 @@
-#include "common.h"
+#include "ovl_39.h"
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_801059A0_2BCE10_tick_tock_hop);
+#define ABS(x) ((x) > 0 ? (x) : -(x))
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_801059BC_2BCE2C_tick_tock_hop);
+// EXTERN
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80105B90_2BD000_tick_tock_hop);
+s32 func_80036C4C_3784C();
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80105C9C_2BD10C_tick_tock_hop);
+void Hu3DModelRotSet(s16, f32, f32, f32);
+void* HuMemAllocTag(s32, s32);
+s32 func_8000B638_C238(void);
+s32 func_80017BB8_187B8(s32, s32);
+f32 func_8001C7D0_1D3D0(s32);
+s32 func_80037030_37C30(void);
+void func_80045010_45C10(const s16*, s32);
+void func_80045F1C_46B1C(s32, s32, s32);
+void func_8004ABE8_4B7E8(s32, s32);
+void func_8004AC10_4B810(s32, s32);
+void func_8004AC98_4B898(s32, s16);
+void func_8004AD50_4B950(s32);
+void func_8004B25C_4BE5C(s16, s32, s32, s32);
+void func_80054FF8_55BF8(s32, s32, s32);
+void func_800E18D8_B4458_name_82(void);
+void func_800E19F0_B4570_name_82(s32);
+void func_800E1BA8_B4728_name_82(omObjData*, s32, s32, u16, s32, s32);
+void func_800E4E30_B79B0_name_82(omObjData*);
+void func_800E5690_B8210_name_82(omObjData*, u16);
+void func_800E5A00_B8580_name_82(omObjData*, s32, s32, s32, s32);
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80105CE4_2BD154_tick_tock_hop);
+extern s32 D_800A178C[][6];
+extern s16 D_800EBE28_BE9A8_name_82;
+extern s16 D_800EC1B8_BED38_name_82;
+extern omObjData* D_800EC1C0_BED40_name_82;
+extern u16 D_800EC280_BEE00_name_82;
+extern omObjData* D_800EC598_BF118_name_82[];
+extern s8 D_800CBB6E_CC76E[];
+extern u16 D_800CDA7C_CE67C[];
+extern f32 D_800CE1C8_CEDC8;
+extern f32 D_800D138C_D1F8C[];
+extern s8 D_800D20A1_D2CA1[];
+extern f32 D_800D6ABC_D76BC[];
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80105D1C_2BD18C_tick_tock_hop);
+// LOCAL
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80105D40_2BD1B0_tick_tock_hop);
+typedef struct {
+    /* 0x00 */ f32 unk00;
+    /* 0x04 */ f32 unk04;
+    /* 0x08 */ f32 unk08;
+    /* 0x0C */ f32 unk0C;
+    /* 0x10 */ s16 unk10;
+    /* 0x12 */ s16 unk12;
+    /* 0x14 */ s16 unk14;
+    /* 0x16 */ s16 unk16;
+    /* 0x18 */ s16 unk18;
+    /* 0x1A */ s16 unk1A;
+    /* 0x1C */ s16 unk1C;
+    /* 0x1E */ s16 unk1E;
+    /* 0x20 */ s16 unk20;
+    /* 0x24 */ f32 unk24;
+    /* 0x28 */ s8 unk28;
+    /* 0x29 */ char unk29[0x33];
+} D_8010E6E0_2C5B50_Struct; // Size 0x5C
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80105E1C_2BD28C_tick_tock_hop);
+void func_801059BC_2BCE2C_tick_tock_hop(void);
+void func_80105B90_2BD000_tick_tock_hop(void);
+void func_80105C9C_2BD10C_tick_tock_hop(omObjData* arg0);
+void func_80105D1C_2BD18C_tick_tock_hop(omObjData* arg0);
+void func_80105CE4_2BD154_tick_tock_hop(omObjData* arg0);
+void func_80105E1C_2BD28C_tick_tock_hop(omObjData* arg0);
+void func_80105FB4_2BD424_tick_tock_hop(omObjData* arg0);
+void func_80105FF0_2BD460_tick_tock_hop(omObjData* arg0);
+void func_80106504_2BD974_tick_tock_hop(omObjData* arg0);
+void func_80106534_2BD9A4_tick_tock_hop(omObjData* arg0);
+void func_801068D4_2BDD44_tick_tock_hop(omObjData* arg0);
+void func_80106904_2BDD74_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80106980_2BDDF0_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80106AA8_2BDF18_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80106D80_2BE1F0_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80107380_2BE7F0_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_801074CC_2BE93C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80107838_2BECA8_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80107E88_2BF2F8_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80108094_2BF504_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+f32 func_801082A0_2BF710_tick_tock_hop(s16 arg0, s16 arg1);
+void func_80108368_2BF7D8_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_8010847C_2BF8EC_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80108678_2BFAE8_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_801087BC_2BFC2C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80108B18_2BFF88_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80108C24_2C0094_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80108D90_2C0200_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_8010908C_2C04FC_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_8010942C_2C089C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_8010955C_2C09CC_tick_tock_hop(D_8010E6E4_2C5B54_Struct* arg0, s32 arg1, s32 arg2);
+void func_80109568_2C09D8_tick_tock_hop(D_8010E6E4_2C5B54_Struct* arg0, s32 arg1);
+void func_80109570_2C09E0_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_801096B0_2C0B20_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80109700_2C0B70_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80105FB4_2BD424_tick_tock_hop);
+D_8010E6E0_2C5B50_Struct* D_8010E6E0_2C5B50_tick_tock_hop;
+D_8010E6E4_2C5B54_Struct* D_8010E6E4_2C5B54_tick_tock_hop;
+s16 D_8010E6E8_2C5B58_tick_tock_hop[2];
+s16 D_8010E6EC_2C5B5C_tick_tock_hop[2];
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80105FF0_2BD460_tick_tock_hop);
+s16 D_8010E4A0_2C5910_tick_tock_hop = 1;
+s16 D_8010E4A2_2C5912_tick_tock_hop = 0;
+s16 D_8010E4A4_2C5914_tick_tock_hop = 0;
+s16 D_8010E4A6_2C5916_tick_tock_hop = 0;
+s16 D_8010E4A8_2C5918_tick_tock_hop = 0;
+s16 D_8010E4AA_2C591A_tick_tock_hop = 0;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80106504_2BD974_tick_tock_hop);
+const s16 D_8010E5F0_2C5A60_tick_tock_hop[] = {
+    0x8272, 0x8273, 0x8260, 0x8271, 0x8273, 0x0000
+};
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80106534_2BD9A4_tick_tock_hop);
+const s16 D_8010E5FC_2C5A6C_tick_tock_hop[] = {
+    0x8265, 0x8268, 0x826D, 0x8268, 0x8272, 0x8267, 0x0000, 0x0000
+};
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_801068D4_2BDD44_tick_tock_hop);
+const s16 D_8010E60C_2C5A7C_tick_tock_hop[] = {
+    0x8263, 0x8271, 0x8260, 0x8276, 0x0000, 0x0000
+};
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80106904_2BDD74_tick_tock_hop);
+void func_801059A0_2BCE10_tick_tock_hop() {
+    func_801059BC_2BCE2C_tick_tock_hop();
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80106980_2BDDF0_tick_tock_hop);
+void func_801059BC_2BCE2C_tick_tock_hop(void) {
+    s32 temp_s0;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80106AA8_2BDF18_tick_tock_hop);
+    Hu3DAnimInit(50);
+    func_800142A0_14EA0(0x30);
+    omInitObjMan(50, 0);
+    func_8004A208_4AE08();
+    omSetStatBit(omAddObj(0x7FDA, 0, 0, -1, func_8004B340_4BF40), 0xA0);
+    HmfLightColorSet(0, 0xFF, 0xFF, 0xFF);
+    HmfLightColorSet(1, 0xFF, 0xFF, 0xFF);
+    HmfLightDirSet(1, -56.0f, 50.0f, 56.0f);
+    func_8000B5F0_C1F0(1);
+    temp_s0 = func_8000B638_C238();
+    ScissorSet(temp_s0, 0.0f, 0.0f, 320.0f, 240.0f);
+    ViewportSet(temp_s0, 640.0f, 480.0f, 511.0f, 640.0f, 480.0f, 511.0f);
+    Hu3DCamSetPerspective(0, 60.0f, 80.0f, 4000.0f);
+    D_800EC1B8_BED38_name_82 = 0;
+    D_800EC280_BEE00_name_82 = 0;
+    D_800EBE28_BE9A8_name_82 = 0;
+    func_80109A00_2C0E70_tick_tock_hop();
+    func_80105B90_2BD000_tick_tock_hop();
+    omAddObj(1000, 0, 0, -1, func_80105E1C_2BD28C_tick_tock_hop);
+    omAddObj(2000, 0, 0, -1, func_80105C9C_2BD10C_tick_tock_hop);
+    func_80045010_45C10(D_8010E5F0_2C5A60_tick_tock_hop, 1);
+    func_80045010_45C10(D_8010E5FC_2C5A6C_tick_tock_hop, 1);
+    func_80045010_45C10(D_8010E60C_2C5A7C_tick_tock_hop, 1);
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80106D14_2BE184_tick_tock_hop);
+void func_80105B90_2BD000_tick_tock_hop(void) {
+    s16 var_a2 = 0;
+    s16 var_a1 = 0;
+    s16 var_a0;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80106D80_2BE1F0_tick_tock_hop);
+    for (var_a0 = 0; var_a0 < 4; var_a0++) {
+        if (GwPlayer[var_a0].group == 0) {
+            if (var_a2 == 0) {
+                D_8010E6E8_2C5B58_tick_tock_hop[0] = var_a0;
+                var_a2 = 1;
+            }
+        } else if (GwPlayer[var_a0].group == 1) {
+            if (var_a1 == 0) {
+                D_8010E6E8_2C5B58_tick_tock_hop[1] = var_a0;
+                var_a1 = 1;
+            }
+        }
+    }
+    D_8010E6E0_2C5B50_tick_tock_hop = HuMemAllocTag(sizeof(*D_8010E6E0_2C5B50_tick_tock_hop), 31000);
+    memset(D_8010E6E0_2C5B50_tick_tock_hop, 0, sizeof(*D_8010E6E0_2C5B50_tick_tock_hop));
+    D_8010E6E4_2C5B54_tick_tock_hop = HuMemAllocTag(2 * sizeof(*D_8010E6E4_2C5B54_tick_tock_hop), 31000);
+    memset(D_8010E6E4_2C5B54_tick_tock_hop, 0, 2 * sizeof(*D_8010E6E4_2C5B54_tick_tock_hop));
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80107140_2BE5B0_tick_tock_hop);
+void func_80105C9C_2BD10C_tick_tock_hop(omObjData* arg0) {
+    if (D_800D530C_D5F0C == 1) {
+        WipeCreateOut(0, 20);
+        arg0->func = func_80105CE4_2BD154_tick_tock_hop;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80107380_2BE7F0_tick_tock_hop);
+void func_80105CE4_2BD154_tick_tock_hop(omObjData* arg0) {
+    if (WipeStatGet() == 0) {
+        arg0->func = func_80105D1C_2BD18C_tick_tock_hop;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_801074CC_2BE93C_tick_tock_hop);
+void func_80105D1C_2BD18C_tick_tock_hop(omObjData* arg0) {
+    osViBlack(0);
+    omOvlReturnEx(1);
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80107838_2BECA8_tick_tock_hop);
+void func_80105D40_2BD1B0_tick_tock_hop(void) {
+    if (D_800D138C_D1F8C[0] > 360.0f) {
+        D_800D138C_D1F8C[0] -= 360.0f;
+    } else if (D_800D138C_D1F8C[0] < 0.0f) {
+        D_800D138C_D1F8C[0] += 360.0f;
+    }
+    if (D_800D138C_D1F8C[1] > 360.0f) {
+        D_800D138C_D1F8C[1] -= 360.0f;
+    } else if (D_800D138C_D1F8C[1] < 0.0f) {
+        D_800D138C_D1F8C[1] += 360.0f;
+    }
+    func_80109E2C_2C129C_tick_tock_hop(0);
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80107E88_2BF2F8_tick_tock_hop);
+void func_80105E1C_2BD28C_tick_tock_hop(omObjData* arg0) {
+    D_8010E6F4_2C5B64_Unk04_Struct* temp_a1;
+    s16 temp_smth;
+    s16 var_s0;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80108094_2BF504_tick_tock_hop);
+    func_800E18D8_B4458_name_82();
+    func_800E19F0_B4570_name_82(1);
+    func_80109A94_2C0F04_tick_tock_hop(NULL, 0, 0, 4);
+    func_80109BE4_2C1054_tick_tock_hop(0, 0, NULL, func_80106904_2BDD74_tick_tock_hop, 0);
+    arg0->work[1] = 1;
+    func_80109A94_2C0F04_tick_tock_hop(arg0, arg0->work[1], 0, 4);
+    temp_smth = func_80109BE4_2C1054_tick_tock_hop(arg0->work[1], 0xFFFF, NULL, func_8010D2FC_2C476C_tick_tock_hop, arg0->work[1]);
+    temp_a1 = &D_8010E6F4_2C5B64_tick_tock_hop[arg0->work[1]].unk04[temp_smth];
+    temp_a1->unk40(NULL, temp_a1);
+    func_8010DA80_2C4EF0_tick_tock_hop(D_8010E6EC_2C5B5C_tick_tock_hop, 2);
+    for (var_s0 = 0; var_s0 < 2; var_s0++) {
+        D_800EC598_BF118_name_82[var_s0] = omAddObj(300, 9, 0x27, -1, func_80106534_2BD9A4_tick_tock_hop);
+    }
+    D_800EC1C0_BED40_name_82 = omAddObj(10, 5, 0, -1, func_80105FF0_2BD460_tick_tock_hop);
+    WipeCreateIn(0xFF, 16);
+    arg0->func = func_80105FB4_2BD424_tick_tock_hop;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_801082A0_2BF710_tick_tock_hop);
+void func_80105FB4_2BD424_tick_tock_hop(omObjData* arg0) {
+    func_80109E2C_2C129C_tick_tock_hop(1);
+    func_80105D40_2BD1B0_tick_tock_hop();
+    func_8010A300_2C1770_tick_tock_hop();
+    func_8010A620_2C1A90_tick_tock_hop();
+    func_8010ABCC_2C203C_tick_tock_hop();
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80108368_2BF7D8_tick_tock_hop);
+void func_80105FF0_2BD460_tick_tock_hop(omObjData* arg0) {
+    D_8010E6F4_2C5B64_Unk00_Struct* temp_s3;
+    s32 var_s4 = 0xB9;
+    s32 var_s0 = 0x4000;
+    D_8010E700_2C5B70_Unk60_Struct sp28 = { {
+        {  30.000002f, 0.0f, 100.0f },
+        { -30.000002f, 0.0f, 100.0f },
+        { -30.000002f, 0.0f, 400.0f },
+        {  30.000002f, 0.0f, 400.0f }
+    } };
+    D_8010E700_2C5B70_Unk60_Struct sp58 = { {
+        {  90.0f, 0.0f, 100.0f },
+        { -90.0f, 0.0f, 100.0f },
+        { -90.0f, 0.0f, 400.0f },
+        {  90.0f, 0.0f, 400.0f }
+    } };
+    f32 sp88[] = { 35.0f, 60.0f, 120.0f, 145.0f, 215.0f, 240.0f, 300.0f, 325.0f };
+    f32 temp_f22;
+    f32 temp_f20;
+    s16 temp_s1;
+    s16 var_s2;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_8010847C_2BF8EC_tick_tock_hop);
+    temp_s3 = func_80109A94_2C0F04_tick_tock_hop(arg0, 2, 5, 16)->unk00;
+    temp_s3->unk04[0] = D_8010E6E0_2C5B50_tick_tock_hop->unk10 = func_8000B108_BD08(0x5A0000, var_s4);
+    temp_s3->unk04[1] = D_8010E6E0_2C5B50_tick_tock_hop->unk12 = func_8000B108_BD08(0x5A0001, var_s4);
+    temp_s3->unk04[2] = func_8000B108_BD08(0x5A0002, var_s4);
+    temp_s3->unk04[3] = func_8000B108_BD08(0x5A0003, var_s4);
+    func_8010A21C_2C168C_tick_tock_hop(func_8010A07C_2C14EC_tick_tock_hop(0xFFFF, 0x5A, 6, 0, var_s0), 0xA0, 0x78);
+    for (var_s2 = 0; var_s2 < 8; var_s2++) {
+        temp_f22 = HuMathSin(sp88[var_s2]) * 600.0f;
+        temp_f20 = HuMathCos(sp88[var_s2]) * 600.0f;
+        if (var_s2 % 2 != 0) {
+            temp_s1 = func_8010A3A8_2C1818_tick_tock_hop(90, 5, 0.25f, 1, var_s4);
+        } else {
+            temp_s1 = func_8010A3A8_2C1818_tick_tock_hop(90, 4, 0.25f, 1, var_s4);
+        }
+        func_8010A4A8_2C1918_tick_tock_hop(temp_s1, temp_f22, -25.0f, temp_f20, 0.0f, 0.0f, 0.0f, 0.4f, rand16() % 31);
+        func_8001C258_1CE58(D_8010E6FC_2C5B6C_tick_tock_hop[temp_s1].unk0A, 4, 0);
+    }
+    D_8010E6E0_2C5B50_tick_tock_hop->unk14 = func_8010A07C_2C14EC_tick_tock_hop(0xF, 0, 0x2D, 0, 0);
+    D_8010E6E0_2C5B50_tick_tock_hop->unk16 = temp_s1 = func_8010A07C_2C14EC_tick_tock_hop(0xF, 0, 0x2D, 0, 0);
+    func_8010A21C_2C168C_tick_tock_hop(temp_s1, 0x118, 0x20);
+    D_8010E6E0_2C5B50_tick_tock_hop->unk00 = 270.0f;
+    D_8010E6E0_2C5B50_tick_tock_hop->unk04 = 0.0f;
+    Hu3DModelRotSet(temp_s3->unk04[0], D_8010E6E0_2C5B50_tick_tock_hop->unk04, D_8010E6E0_2C5B50_tick_tock_hop->unk00, D_8010E6E0_2C5B50_tick_tock_hop->unk04);
+    Hu3DModelRotSet(temp_s3->unk04[1], 0.0f, D_8010E6E0_2C5B50_tick_tock_hop->unk04, 0.0f);
+    Hu3DModelPosSet(temp_s3->unk04[0], 0.0f, 25.0f, 0.0f);
+    Hu3DModelPosSet(temp_s3->unk04[1], 0.0f, 0.0f, 0.0f);
+    Hu3DModelPosSet(temp_s3->unk04[2], 0.0f, 30.0f, 0.0f);
+    Hu3DModelPosSet(temp_s3->unk04[3], 0.0f, -40.0f, 0.0f);
+    func_80109BE4_2C1054_tick_tock_hop(2, 0xF, NULL, func_80108094_2BF504_tick_tock_hop, 0);
+    func_80109BE4_2C1054_tick_tock_hop(2, 0xF, NULL, func_80107E88_2BF2F8_tick_tock_hop, 0);
+    D_8010E6E0_2C5B50_tick_tock_hop->unk18 = func_8010D34C_2C47BC_tick_tock_hop(temp_s3->unk04[0], &sp28, 25.0f, 2, 1);
+    D_8010E6E0_2C5B50_tick_tock_hop->unk1A = func_8010D34C_2C47BC_tick_tock_hop(temp_s3->unk04[0], &sp58, 0.0f, 2, 4);
+    D_8010E6E0_2C5B50_tick_tock_hop->unk08 = 0.0f;
+    D_8010E6E0_2C5B50_tick_tock_hop->unk0C = 0.0f;
+    D_8010E6E0_2C5B50_tick_tock_hop->unk28 = 0;
+    arg0->model[0] = temp_s3->unk04[0];
+    func_8010DB8C_2C4FFC_tick_tock_hop(arg0);
+    func_80109BE4_2C1054_tick_tock_hop(2, 0, NULL, func_801074CC_2BE93C_tick_tock_hop, 0);
+    arg0->func = func_80106504_2BD974_tick_tock_hop;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80108678_2BFAE8_tick_tock_hop);
+void func_80106504_2BD974_tick_tock_hop(omObjData* arg0) {
+    func_80109E2C_2C129C_tick_tock_hop(2);
+    func_8010DB8C_2C4FFC_tick_tock_hop(arg0);
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_801087BC_2BFC2C_tick_tock_hop);
+void func_80106534_2BD9A4_tick_tock_hop(omObjData* arg0) {
+    D_8010E6E4_2C5B54_Struct* temp_s0;
+    s32 var_a0 = 0x2B9;
+    s32 temp_a1;
+    s32 temp_a2;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80108B18_2BFF88_tick_tock_hop);
+    arg0->work[0] = D_800EC280_BEE00_name_82;
+    temp_s0 = &D_8010E6E4_2C5B54_tick_tock_hop[D_800EC280_BEE00_name_82];
+    temp_s0->unk02 = GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[D_800EC280_BEE00_name_82]].chr;
+    temp_a1 = D_800A178C[temp_s0->unk02][0];
+    temp_a2 = D_800A178C[temp_s0->unk02][1];
+    func_800E1BA8_B4728_name_82(arg0, temp_a1, temp_a2, D_8010E6E8_2C5B58_tick_tock_hop[arg0->work[0]], var_a0, var_a0);
+    arg0->model[7] = func_8000B108_BD08(8, var_a0);
+    func_8001C258_1CE58(arg0->model[7], 4, 4);
+    temp_s0->unk52 = func_8010A788_2C1BF8_tick_tock_hop(0x57, 0x10, 0xB);
+    func_800E5A00_B8580_name_82(arg0, 0, func_80017BB8_187B8(temp_s0->unk02, 0), 1, 0);
+    func_800E5A00_B8580_name_82(arg0, 2, func_80017BB8_187B8(temp_s0->unk02, 2), 1, 0);
+    func_800E5A00_B8580_name_82(arg0, 6, func_80017BB8_187B8(temp_s0->unk02, 4), 1, 19);
+    func_800E5A00_B8580_name_82(arg0, 0x15, func_80017BB8_187B8(temp_s0->unk02, 0x1F), 1, 999);
+    func_800E5A00_B8580_name_82(arg0, 0xD, func_80017BB8_187B8(temp_s0->unk02, 0x30), 1, 999);
+    func_800E5A00_B8580_name_82(arg0, 0xE, func_80017BB8_187B8(temp_s0->unk02, 0x1A), 1, 0);
+    func_800E5A00_B8580_name_82(arg0, 0x26, func_80017BB8_187B8(temp_s0->unk02, 0x36), 1, 999);
+    func_8010955C_2C09CC_tick_tock_hop(temp_s0, 0, 1);
+    temp_s0->unk0C = -1;
+    temp_s0->unk00 = ((s8*) arg0->data)[0x57]; // TODO: figure out type.
+    temp_s0->unk04 = 1;
+    arg0->rot.x = arg0->rot.y = arg0->rot.z = 0.0f;
+    arg0->scale.x = arg0->scale.y = arg0->scale.z = 1.0f;
+    D_800EC280_BEE00_name_82++;
+    temp_s0->unk40 = func_8010D49C_2C490C_tick_tock_hop(D_8010E6E0_2C5B50_tick_tock_hop->unk18, arg0->model[0]);
+    temp_s0->unk44 = func_8010D49C_2C490C_tick_tock_hop(D_8010E6E0_2C5B50_tick_tock_hop->unk1A, arg0->model[0]);
+    arg0->work[1] = arg0->work[0] + 3;
+    func_80109A94_2C0F04_tick_tock_hop(arg0, arg0->work[1], 0, 0xA);
+    temp_s0->unk20 = arg0->work[1];
+    temp_s0->unk22 = func_80109BE4_2C1054_tick_tock_hop(arg0->work[1], 0, temp_s0, func_801096B0_2C0B20_tick_tock_hop, 0);
+    func_80109BE4_2C1054_tick_tock_hop(arg0->work[1], 0xF, temp_s0, func_80108368_2BF7D8_tick_tock_hop, 0);
+    func_80109BE4_2C1054_tick_tock_hop(arg0->work[1], 0x1F, temp_s0, func_8010847C_2BF8EC_tick_tock_hop, 0);
+    func_80109BE4_2C1054_tick_tock_hop(arg0->work[1], 0x1F, temp_s0, func_80108678_2BFAE8_tick_tock_hop, 0);
+    func_80109BE4_2C1054_tick_tock_hop(arg0->work[1], 0xEFFF, temp_s0, func_80108B18_2BFF88_tick_tock_hop, 0);
+    func_80109BE4_2C1054_tick_tock_hop(arg0->work[1], 0xFFFF, temp_s0, func_8010942C_2C089C_tick_tock_hop, 0);
+    arg0->func = func_801068D4_2BDD44_tick_tock_hop;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80108C24_2C0094_tick_tock_hop);
+void func_801068D4_2BDD44_tick_tock_hop(omObjData* arg0) {
+    func_80109E2C_2C129C_tick_tock_hop(arg0->work[1]);
+    func_800E4E30_B79B0_name_82(arg0);
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80108D90_2C0200_tick_tock_hop);
+void func_80106904_2BDD74_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_800D6ABC_D76BC[0] = 0.0f;
+    D_800D6ABC_D76BC[1] = 0.0f;
+    D_800D6ABC_D76BC[2] = -137.0f;
+    D_800D138C_D1F8C[0] = 298.0f;
+    D_800D138C_D1F8C[1] = 180.0f;
+    D_800D138C_D1F8C[2] = 0.0f;
+    D_800CE1C8_CEDC8 = 990.0f;
+    func_80109CC0_2C1130_tick_tock_hop(0, arg1);
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_8010908C_2C04FC_tick_tock_hop);
+void func_80106980_2BDDF0_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    s16 temp_s1;
+    s16 temp_f2;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_8010942C_2C089C_tick_tock_hop);
+    temp_s1 = D_8010E6E0_2C5B50_tick_tock_hop->unk1C % 10;
+    temp_f2 = D_8010E6E0_2C5B50_tick_tock_hop->unk1C * 0.1f;
+    if (temp_f2 != 0) {
+        func_8010A21C_2C168C_tick_tock_hop(D_8010E6E0_2C5B50_tick_tock_hop->unk14, 0x108, 0x20);
+    } else {
+        func_8010A2B0_2C1720_tick_tock_hop(D_8010E6E0_2C5B50_tick_tock_hop->unk14);
+    }
+    func_80054FF8_55BF8(D_8010E6F8_2C5B68_tick_tock_hop[D_8010E6E0_2C5B50_tick_tock_hop->unk14].unk01, 0, temp_f2);
+    func_80054FF8_55BF8(D_8010E6F8_2C5B68_tick_tock_hop[D_8010E6E0_2C5B50_tick_tock_hop->unk16].unk01, 0, temp_s1);
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_8010955C_2C09CC_tick_tock_hop);
+void func_80106AA8_2BDF18_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    s16 var_s0;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80109568_2C09D8_tick_tock_hop);
+    if (arg1->unk04 == 0) {
+        arg1->unk1C[0] = 0;
+        arg1->unk04 = 1;
+    }
+    arg1->unk1C[0]++;
+    switch (arg1->unk1C[0]) {
+        case 5:
+            func_80036C4C_3784C(6);
+            HuAudFXPlay(0xE);
+            D_8010E4A4_2C5914_tick_tock_hop = 1;
+            break;
+        case 30:
+            D_8010E4A2_2C5912_tick_tock_hop = 1;
+            break;
+        default:
+            if (D_8010E4A2_2C5912_tick_tock_hop != 0 && func_80037030_37C30() == 2) {
+                D_8010E4A0_2C5910_tick_tock_hop = 1;
+                D_8010E6E0_2C5B50_tick_tock_hop->unk08 = 0.0f;
+                D_8010E6E0_2C5B50_tick_tock_hop->unk0C = 3.0f;
+                for (var_s0 = 0; var_s0 < 2; var_s0++) {
+                    if (GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[var_s0]].stat & 1) {
+                        func_80109BE4_2C1054_tick_tock_hop(var_s0 + 3, 0, &D_8010E6E4_2C5B54_tick_tock_hop[var_s0], func_80109570_2C09E0_tick_tock_hop, 0);
+                    } else {
+                        func_80109CC0_2C1130_tick_tock_hop(D_8010E6E4_2C5B54_tick_tock_hop[var_s0].unk20, &D_8010E6F4_2C5B64_tick_tock_hop[D_8010E6E4_2C5B54_tick_tock_hop[var_s0].unk20].unk04[D_8010E6E4_2C5B54_tick_tock_hop[var_s0].unk22]);
+                    }
+                }
+                func_80109BE4_2C1054_tick_tock_hop(1, 0, NULL, func_80106980_2BDDF0_tick_tock_hop, 0);
+                arg1->unk40 = func_80106D80_2BE1F0_tick_tock_hop;
+            }
+            break;
+    }
+    if (D_8010E4A4_2C5914_tick_tock_hop != 0 && func_80037030_37C30() != 0) {
+        D_8010E4A4_2C5914_tick_tock_hop++;
+        if (D_8010E4A4_2C5914_tick_tock_hop >= 45) {
+            HuAudSeqPlay(0x2F);
+            D_8010E4A4_2C5914_tick_tock_hop = 0;
+        }
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80109570_2C09E0_tick_tock_hop);
+void func_80106D14_2BE184_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    switch (arg1->unk04) {
+        case 0:
+            WipeCreateOut(0, 20);
+            arg1->unk04 = 1;
+            break;
+        case 1:
+            if (WipeStatGet() == 0) {
+                omOvlReturnEx(1);
+            }
+            break;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_801096B0_2C0B20_tick_tock_hop);
+void func_80106D80_2BE1F0_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* var_a1 = D_8010E6E4_2C5B54_tick_tock_hop;
+    s16 sp18[2];
+    f32 sp20;
+    f32 sp24;
+    s16 var_a0;
+    s16 var_s0;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2BCE10", func_80109700_2C0B70_tick_tock_hop);
+    sp18[0] = -1;
+    sp18[1] = -1;
+    if (D_8010E6E0_2C5B50_tick_tock_hop->unk1C == 99) {
+        if (D_8010E6E0_2C5B50_tick_tock_hop->unk28 == 0) {
+            D_8010E6E0_2C5B50_tick_tock_hop->unk28 = 1;
+        }
+        sp20 = HmfModelData[D_8010E6E0_2C5B50_tick_tock_hop->unk12].unk2C;
+        sp24 = HmfModelData[D_8010E6E0_2C5B50_tick_tock_hop->unk10].unk2C;
+        func_8010DE30_2C52A0_tick_tock_hop(&sp20, &sp24);
+        if (ABS(sp20 - sp24) > 90.0f) {
+            D_8010E6E0_2C5B50_tick_tock_hop->unk08 = D_8010E6E0_2C5B50_tick_tock_hop->unk0C = 0.0f;
+            func_8004A994_4B594(0x78);
+            func_80036C4C_3784C(0x11);
+            func_80109BE4_2C1054_tick_tock_hop(1, 0, NULL, func_80107380_2BE7F0_tick_tock_hop, 0);
+            for (var_a0 = 0; var_a0 < 2; var_a0++) {
+                D_8010E6E4_2C5B54_tick_tock_hop[var_a0].unk04 |= 8;
+            }
+            func_80109CC0_2C1130_tick_tock_hop(1, arg1);
+        }
+    } else {
+        var_s0 = 0;
+        for (var_a0 = 0; var_a0 < 2; var_a0++, var_a1++) {
+            if (var_a1->unk04 & 8) {
+                sp18[var_s0] = var_a0;
+                var_s0++;
+            }
+        }
+        if (var_s0 == 0) {
+            return;
+        }
+        if (D_8010E6E0_2C5B50_tick_tock_hop->unk28 == 0) {
+            D_8010E6E0_2C5B50_tick_tock_hop->unk28 = 1;
+        }
+        sp20 = HmfModelData[D_8010E6E0_2C5B50_tick_tock_hop->unk12].unk2C;
+        sp24 = HmfModelData[D_8010E6E0_2C5B50_tick_tock_hop->unk10].unk2C;
+        func_8010DE30_2C52A0_tick_tock_hop(&sp20, &sp24);
+        if (ABS(sp20 - sp24) > 90.0f) {
+            D_8010E6E0_2C5B50_tick_tock_hop->unk08 = D_8010E6E0_2C5B50_tick_tock_hop->unk0C = 0.0f;
+            func_8004A994_4B594(0x78);
+            func_80036C4C_3784C(0x11);
+            if (var_s0 == 2) {
+                func_80109CC0_2C1130_tick_tock_hop(1, arg1);
+                func_80109BE4_2C1054_tick_tock_hop(1, 0, NULL, func_80107380_2BE7F0_tick_tock_hop, 0);
+            } else {
+                var_a0 = (sp18[0] == 0);
+                D_8010E6E4_2C5B54_tick_tock_hop[var_a0].unk04 |= 0x10;
+                func_80109BE4_2C1054_tick_tock_hop(var_a0 + 3, 0xFF, &D_8010E6E4_2C5B54_tick_tock_hop[var_a0], func_80108D90_2C0200_tick_tock_hop, 0);
+                func_80109CC0_2C1130_tick_tock_hop(1, arg1);
+            }
+        }
+    }
+}
+
+void func_80107140_2BE5B0_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_s2 = &D_8010E6E4_2C5B54_tick_tock_hop[0];
+    D_8010E6E4_2C5B54_Struct* temp_s3 = &D_8010E6E4_2C5B54_tick_tock_hop[1];
+
+    if (arg1->unk04 == 0) {
+        arg1->unk1C[0] = 0;
+        arg1->unk04 = 1;
+    }
+    if (D_8010E4A6_2C5916_tick_tock_hop == 0) {
+        if (func_80037030_37C30() == 0) {
+            D_8010E4A6_2C5916_tick_tock_hop = 1;
+        }
+    } else if (D_8010E4A6_2C5916_tick_tock_hop >= 2) {
+        if (func_80037030_37C30() == 0) {
+            D_8010E4A6_2C5916_tick_tock_hop = 3;
+        }
+        if (D_8010E4A6_2C5916_tick_tock_hop == 3) {
+            arg1->unk1C[0]++;
+            if (arg1->unk1C[0] >= 15) {
+                func_80109CC0_2C1130_tick_tock_hop(1, arg1);
+                func_80109BE4_2C1054_tick_tock_hop(1, 0, NULL, func_80106D14_2BE184_tick_tock_hop, 0);
+            }
+        }
+    } else {
+        arg1->unk1C[0]++;
+        if (arg1->unk1C[0] == 15) {
+            HuAudSeqPlay(0x67);
+            func_8010955C_2C09CC_tick_tock_hop(temp_s2, 0xD, 1);
+            func_8010955C_2C09CC_tick_tock_hop(temp_s3, 0xD, 1);
+            func_8004AC98_4B898(GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[0]].chr + 0x290, D_8010E6E8_2C5B58_tick_tock_hop[0]);
+            func_8004AC98_4B898(GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[1]].chr + 0x290, D_8010E6E8_2C5B58_tick_tock_hop[1]);
+            func_80036C4C_3784C(0x1E, temp_s2->unk02, temp_s3->unk02);
+            GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[D_800EC598_BF118_name_82[0]->work[0]]].bonusCoin += 10;
+            GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[D_800EC598_BF118_name_82[1]->work[0]]].bonusCoin += 10;
+        }
+        if (func_80037030_37C30() != 0) {
+            arg1->unk1C[0] = 0;
+            D_8010E4A6_2C5916_tick_tock_hop = 2;
+        }
+    }
+}
+
+void func_80107380_2BE7F0_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    if (arg1->unk04 == 0) {
+        arg1->unk1C[0] = 0;
+        arg1->unk04 = 1;
+    }
+    if (D_8010E4A8_2C5918_tick_tock_hop == 0) {
+        if (func_80037030_37C30() == 0) {
+            D_8010E4A8_2C5918_tick_tock_hop = 1;
+        }
+    } else if (D_8010E4A8_2C5918_tick_tock_hop >= 2) {
+        if (func_80037030_37C30() == 0) {
+            D_8010E4A8_2C5918_tick_tock_hop = 3;
+        }
+        if (D_8010E4A8_2C5918_tick_tock_hop == 3) {
+            arg1->unk1C[0]++;
+            if (arg1->unk1C[0] >= 15) {
+                func_80109CC0_2C1130_tick_tock_hop(1, arg1);
+                func_80109BE4_2C1054_tick_tock_hop(1, 0, NULL, func_80106D14_2BE184_tick_tock_hop, 0);
+            }
+        }
+    } else {
+        arg1->unk1C[0]++;
+        if (arg1->unk1C[0] == 15) {
+            func_8010955C_2C09CC_tick_tock_hop(&D_8010E6E4_2C5B54_tick_tock_hop[0], 0x26, 1);
+            func_8010955C_2C09CC_tick_tock_hop(&D_8010E6E4_2C5B54_tick_tock_hop[1], 0x26, 1);
+            func_80036C4C_3784C(0x20);
+            HuAudSeqPlay(0x6C);
+        }
+        if (func_80037030_37C30() != 0) {
+            arg1->unk1C[0] = 0;
+            D_8010E4A8_2C5918_tick_tock_hop = 2;
+        }
+    }
+}
+
+void func_801074CC_2BE93C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    s16 var_s1;
+
+    switch (arg1->unk04) {
+        case 0:
+            arg1->unk0C = 0;
+            arg1->unk22 = 0;
+            for (var_s1 = 0; var_s1 < 2; var_s1++) {
+                arg1->unk1C[var_s1] = func_80109BE4_2C1054_tick_tock_hop(var_s1 + 3, 0xF, &D_8010E6E4_2C5B54_tick_tock_hop[var_s1], func_80108C24_2C0094_tick_tock_hop, 0);
+            }
+            arg1->unk04 = 1;
+            break;
+        case 1:
+            arg1->unk22++;
+            if (arg1->unk22 < 30.0f) {
+                return;
+            }
+            arg1->unk04 = 2;
+            HuAudFXPlay(0x4BB);
+            arg1->unk24 = HuAudFXPlay(0x4BC);
+            func_8004ABE8_4B7E8(arg1->unk24, 0);
+            break;
+    }
+    if (arg1->unk0C == 0) {
+        D_8010E6E0_2C5B50_tick_tock_hop->unk04 -= 4.0f;
+        if (D_8010E6E0_2C5B50_tick_tock_hop->unk04 < 0.0f) {
+            D_8010E6E0_2C5B50_tick_tock_hop->unk04 += 360.0f;
+        }
+        if (D_8010E6E0_2C5B50_tick_tock_hop->unk04 < 180.0f) {
+            func_8004AD50_4B950(arg1->unk24);
+            arg1->unk10 = 0;
+            arg1->unk0C = 1;
+        }
+    } else if (++arg1->unk0C >= 11) {
+        if (arg1->unk0D == 0) {
+            arg1->unk24 = HuAudFXPlay(0x4BC);
+            func_8004ABE8_4B7E8(arg1->unk24, 0);
+            HuAudFXPlay(0x4BB);
+            arg1->unk0D = 1;
+        }
+        arg1->unk0C = 10;
+        D_8010E6E0_2C5B50_tick_tock_hop->unk04 += 4.0f;
+        if (D_8010E6E0_2C5B50_tick_tock_hop->unk04 > 360.0f) {
+            func_80109BE4_2C1054_tick_tock_hop(1, 0, NULL, func_80106AA8_2BDF18_tick_tock_hop, 0);
+            for (var_s1 = 0; var_s1 < 2; var_s1++) {
+                func_80109CC0_2C1130_tick_tock_hop(var_s1 + 3, &D_8010E6F4_2C5B64_tick_tock_hop[var_s1 + 3].unk04[arg1->unk1C[var_s1]]);
+            }
+            D_8010E4A0_2C5910_tick_tock_hop = 0;
+            D_8010E700_2C5B70_tick_tock_hop[D_8010E6E0_2C5B50_tick_tock_hop->unk18].unk00 &= ~1;
+            D_8010E700_2C5B70_tick_tock_hop[D_8010E6E0_2C5B50_tick_tock_hop->unk18].unk00 = D_8010E700_2C5B70_tick_tock_hop[D_8010E6E0_2C5B50_tick_tock_hop->unk18].unk00;
+            func_8004AD50_4B950(arg1->unk24);
+            arg1->unk0D = 0;
+            arg1->unk40 = func_80107838_2BECA8_tick_tock_hop;
+            arg1->unk04 = 0;
+        }
+    }
+}
+
+void func_80107838_2BECA8_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_s2 = D_8010E6E4_2C5B54_tick_tock_hop;
+    s16 var_v0 = 0;
+    f32 sp10;
+    f32 sp14;
+
+    if (D_8010E6E0_2C5B50_tick_tock_hop->unk28 != 0) {
+        return;
+    }
+    if (arg1->unk04 == 0) {
+        arg1->unk0C = 0;
+        D_8010E6E0_2C5B50_tick_tock_hop->unk24 = 1.0f;
+        D_8010E6E0_2C5B50_tick_tock_hop->unk1C = 0;
+        D_8010E6E0_2C5B50_tick_tock_hop->unk1E = 0;
+        D_8010E6E0_2C5B50_tick_tock_hop->unk20 = rand16() % 3 + 1;
+        arg1->unk04 = 1;
+    }
+    if (temp_s2->unk44->unk00 != 0) {
+        if (arg1->unk0C == 0) {
+            arg1->unk0C = 1;
+        }
+    } else {
+        if (arg1->unk0C != 0) {
+            D_8010E6E0_2C5B50_tick_tock_hop->unk1E = (u16) (D_8010E6E0_2C5B50_tick_tock_hop->unk1E + 1);
+            D_8010E6E0_2C5B50_tick_tock_hop->unk1C++;
+            D_8010E6E0_2C5B50_tick_tock_hop->unk24 = D_8010E6E0_2C5B50_tick_tock_hop->unk1C * 0.03f + 1.0f;
+        }
+        arg1->unk0C = 0;
+    }
+    if (D_8010E6E0_2C5B50_tick_tock_hop->unk1E > D_8010E6E0_2C5B50_tick_tock_hop->unk20) {
+        if (arg1->unk0D == 0) {
+            var_v0 = 0;
+            arg1->unk0D = 1;
+            arg1->unk38 = 120 + rand16() % 60;
+            switch (rand16() % 3) {
+                case 0:
+                    if (rand16() & 1) {
+                        arg1->unk2C = 0.0f;
+                        arg1->unk30 = func_801082A0_2BF710_tick_tock_hop(3, 4);
+                    } else {
+                        arg1->unk2C = func_801082A0_2BF710_tick_tock_hop(3, 4);
+                        arg1->unk30 = 0.0f;
+                    }
+                    break;
+                case 1:
+                    if (rand16() & 1) {
+                        if (rand16() & 1) {
+                            arg1->unk2C = 3.0f;
+                            arg1->unk30 = 1.0f;
+                        } else {
+                            arg1->unk2C = 1.0f;
+                            arg1->unk30 = 3.0f;
+                        }
+                    } else {
+                        if (rand16() & 1) {
+                            arg1->unk2C = -3.0f;
+                            arg1->unk30 = -1.0f;
+                        } else {
+                            arg1->unk2C = -1.0f;
+                            arg1->unk30 = -3.0f;
+                        }
+                    }
+                    break;
+                case 2:
+                    arg1->unk2C = func_801082A0_2BF710_tick_tock_hop(2, 3);
+                    if (arg1->unk2C > 0.0f) {
+                        arg1->unk30 = -(f32) ((rand16() & 1) + 2);
+                    } else {
+                        arg1->unk30 = (f32) ((rand16() & 1) + 2);
+                    }
+                    break;
+            }
+        } else {
+            var_v0 = 0;
+            sp10 = HmfModelData[arg0->unk04[1]].unk2C;
+            sp14 = HmfModelData[arg0->unk04[0]].unk2C;
+            func_8010DE30_2C52A0_tick_tock_hop(&sp10, &sp14);
+            if (arg1->unk38 < ABS(sp10 - sp14)) {
+                if (D_8010E6E0_2C5B50_tick_tock_hop->unk0C > 0.0f) {
+                    if (arg1->unk2C < 0.0f) {
+                        HuAudFXPlay(0x4BB);
+                        var_v0 = 1;
+                    }
+                } else if (D_8010E6E0_2C5B50_tick_tock_hop->unk0C < 0.0f) {
+                    if (arg1->unk2C > 0.0f) {
+                        HuAudFXPlay(0x4BB);
+                        var_v0 = 1;
+                    }
+                } else {
+                    if (arg1->unk2C != 0.0f) {
+                        HuAudFXPlay(0x4BB);
+                        var_v0 = 1;
+                    }
+                }
+                if (var_v0 == 0) {
+                    if (D_8010E6E0_2C5B50_tick_tock_hop->unk08 > 0.0f) {
+                        if (arg1->unk30 < 0.0f) {
+                            HuAudFXPlay(0x4BB);
+                        }
+                    } else if (D_8010E6E0_2C5B50_tick_tock_hop->unk08 < 0.0f) {
+                        if (arg1->unk30 > 0.0f) {
+                            HuAudFXPlay(0x4BB);
+                        }
+                    } else {
+                        if (arg1->unk30 != 0.0f) {
+                            HuAudFXPlay(0x4BB);
+                        }
+                    }
+                }
+                D_8010E6E0_2C5B50_tick_tock_hop->unk0C = arg1->unk2C;
+                D_8010E6E0_2C5B50_tick_tock_hop->unk08 = arg1->unk30;
+                arg1->unk0D = 0;
+                D_8010E6E0_2C5B50_tick_tock_hop->unk1E = 0;
+                D_8010E6E0_2C5B50_tick_tock_hop->unk20 = (rand16() & 1) + 2;
+            }
+        }
+    }
+}
+
+void func_80107E88_2BF2F8_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    s32 var_a0;
+    s16 var_s1;
+    s16 var_a1;
+    s16 var_a1_0;
+
+    var_s1 = arg1->unk1C[0];
+    D_8010E6E0_2C5B50_tick_tock_hop->unk04 += D_8010E6E0_2C5B50_tick_tock_hop->unk0C * D_8010E6E0_2C5B50_tick_tock_hop->unk24;
+    if (D_8010E6E0_2C5B50_tick_tock_hop->unk04 < 0.0f) {
+        D_8010E6E0_2C5B50_tick_tock_hop->unk04 += 360.0f;
+    } else if (D_8010E6E0_2C5B50_tick_tock_hop->unk04 > 360.0f) {
+        D_8010E6E0_2C5B50_tick_tock_hop->unk04 -= 360.0f;
+    }
+    Hu3DModelRotSet(arg0->unk04[0], 0.0f, D_8010E6E0_2C5B50_tick_tock_hop->unk04, 0.0f);
+    if (D_8010E6E0_2C5B50_tick_tock_hop->unk0C != 0.0f) {
+        if (arg1->unk0C == 0) {
+            var_s1 = arg1->unk1C[0] = HuAudFXPlay(0x4BC);
+            arg1->unk0C = 1;
+        }
+        var_a1_0 = D_8010E6E0_2C5B50_tick_tock_hop->unk24 * 150.0f;
+        switch ((s16) ABS(D_8010E6E0_2C5B50_tick_tock_hop->unk0C)) {
+            case 1:
+                var_a0 = var_s1;
+                var_a1 = var_a1_0;
+                func_8004ABE8_4B7E8(var_a0, var_a1);
+                break;
+            case 2:
+                var_a0 = var_s1;
+                var_a1 = var_a1_0 + 150;
+                func_8004ABE8_4B7E8(var_a0, var_a1);
+                break;
+            case 3:
+                var_a0 = var_s1;
+                var_a1 = var_a1_0 + 300;
+                func_8004ABE8_4B7E8(var_a0, var_a1);
+                break;
+            case 4:
+                var_a0 = var_s1;
+                var_a1 = var_a1_0 + 450;
+                func_8004ABE8_4B7E8(var_a0, var_a1);
+                break;
+        }
+    } else if (arg1->unk0C != 0) {
+        func_8004AD50_4B950(var_s1);
+        arg1->unk0C = 0;
+    }
+}
+
+void func_80108094_2BF504_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    s32 var_a0;
+    s16 var_s1;
+    s16 var_a1;
+    s16 var_a1_0;
+
+    var_s1 = arg1->unk1C[0];
+    D_8010E6E0_2C5B50_tick_tock_hop->unk00 += D_8010E6E0_2C5B50_tick_tock_hop->unk08 * D_8010E6E0_2C5B50_tick_tock_hop->unk24;
+    if (D_8010E6E0_2C5B50_tick_tock_hop->unk00 < 0.0f) {
+        D_8010E6E0_2C5B50_tick_tock_hop->unk00 += 360.0f;
+    } else if (D_8010E6E0_2C5B50_tick_tock_hop->unk00 > 360.0f) {
+        D_8010E6E0_2C5B50_tick_tock_hop->unk00 -= 360.0f;
+    }
+    Hu3DModelRotSet(arg0->unk04[1], 0.0f, D_8010E6E0_2C5B50_tick_tock_hop->unk00, 0.0f);
+    if (D_8010E6E0_2C5B50_tick_tock_hop->unk08 != 0.0f) {
+        if (arg1->unk0C == 0) {
+            var_s1 = arg1->unk1C[0] = HuAudFXPlay(0x4BD);
+            arg1->unk0C = 1;
+        }
+        var_a1_0 = D_8010E6E0_2C5B50_tick_tock_hop->unk24 * 150.0f;
+        switch ((s16) ABS(D_8010E6E0_2C5B50_tick_tock_hop->unk08)) {
+            case 1:
+                var_a0 = var_s1;
+                var_a1 = var_a1_0;
+                func_8004ABE8_4B7E8(var_a0, var_a1);
+                break;
+            case 2:
+                var_a0 = var_s1;
+                var_a1 = var_a1_0 + 150;
+                func_8004ABE8_4B7E8(var_a0, var_a1);
+                break;
+            case 3:
+                var_a0 = var_s1;
+                var_a1 = var_a1_0 + 300;
+                func_8004ABE8_4B7E8(var_a0, var_a1);
+                break;
+            case 4:
+                var_a0 = var_s1;
+                var_a1 = var_a1_0 + 450;
+                func_8004ABE8_4B7E8(var_a0, var_a1);
+                break;
+        }
+    } else if (arg1->unk0C != 0) {
+        func_8004AD50_4B950(var_s1);
+        arg1->unk0C = 0;
+    }
+}
+
+f32 func_801082A0_2BF710_tick_tock_hop(s16 arg0, s16 arg1) {
+    f32 var_f20;
+
+    var_f20 = rand16() % (arg1 - arg0 + 1) + arg0;
+    if (rand16() & 1) {
+        var_f20 = -var_f20;
+    }
+    return var_f20;
+}
+
+void func_80108368_2BF7D8_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_a2 = arg1->unk3C;
+    omObjData* temp_s0 = arg0->unk00;
+    D_8010E6F4_2C5B64_Unk04_Struct* temp_a1;
+
+    if (D_8010E4A0_2C5910_tick_tock_hop == 0) {
+        return;
+    }
+    if (temp_a2->unk04 & 0x18) {
+        func_80109CC0_2C1130_tick_tock_hop(temp_s0->work[1], arg1);
+    } else if (D_800CDA7C_CE67C[temp_a2->unk00] & 0x8000) {
+        if (arg1->unk0C == 0 && !(temp_a2->unk04 & 2) && temp_a2->unk0A != 0x15) {
+            arg1->unk0C = 1;
+            temp_a2->unk04 |= 2;
+            temp_a1 = &D_8010E6F4_2C5B64_tick_tock_hop[temp_s0->work[1]].unk04[func_80109BE4_2C1054_tick_tock_hop(temp_s0->work[1], 0xEFFF, temp_a2, func_801087BC_2BFC2C_tick_tock_hop, 0)];
+            temp_a1->unk40(arg0, temp_a1);
+        }
+    } else {
+        arg1->unk0C = 0;
+    }
+}
+
+void func_8010847C_2BF8EC_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* var_v1 = arg1->unk3C;
+    omObjData* temp_s1 = arg0->unk00;
+    f32 temp_f20 = D_8010E6E0_2C5B50_tick_tock_hop->unk00;
+
+    if (var_v1->unk04 & 8) {
+        return;
+    }
+    if (arg1->unk04 == 0) {
+        if (D_8010E6EC_2C5B5C_tick_tock_hop[temp_s1->work[0]] == 0) {
+            arg1->unk2C = 185.0f;
+            arg1->unk30 = 185.0f;
+        } else {
+            arg1->unk2C = 315.0f;
+            arg1->unk30 = 315.0f;
+        }
+        arg1->unk04 = 1;
+    }
+    temp_s1->trans.x = HuMathSin(temp_f20) * arg1->unk2C;
+    temp_s1->trans.z = HuMathCos(temp_f20) * arg1->unk30;
+    HmfModelData[temp_s1->model[1]].unk1C = temp_s1->trans.x;
+    HmfModelData[temp_s1->model[1]].unk24 = temp_s1->trans.z;
+    if (ABS(D_8010E6E0_2C5B50_tick_tock_hop->unk00 - D_8010E6E0_2C5B50_tick_tock_hop->unk04) < 10.0f) {
+        HmfModelData[temp_s1->model[1]].unk20 = 30.0f;
+    } else {
+        HmfModelData[temp_s1->model[1]].unk20 = 5.0f;
+    }
+}
+
+void func_80108678_2BFAE8_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_s0 = arg1->unk3C;
+    omObjData* temp_s1 = arg0->unk00;
+    Vec sp20;
+    Vec sp30;
+    f32 sp40[3];
+
+    if (temp_s0->unk04 & 0x18) {
+        func_80109CC0_2C1130_tick_tock_hop(temp_s1->work[1], arg1);
+        return;
+    }
+    if (temp_s0->unk0A == 0x15 || temp_s0->unk0A == 6) {
+        return;
+    }
+    if (D_800CBB6E_CC76E[temp_s0->unk00] == 0 && D_800D20A1_D2CA1[temp_s0->unk00] == 0) {
+        func_8010955C_2C09CC_tick_tock_hop(temp_s0, 0, 1);
+    } else {
+        func_8010955C_2C09CC_tick_tock_hop(temp_s0, 2, 1);
+        sp20.x = -D_800CBB6E_CC76E[temp_s0->unk00];
+        sp20.y = 0.0f;
+        sp20.z = D_800D20A1_D2CA1[temp_s0->unk00];
+        sp30.x = 0.0f;
+        sp30.y = 0.0f;
+        sp30.z = 0.0f;
+        func_8010DD00_2C5170_tick_tock_hop(sp30, sp20, sp40);
+        temp_s1->rot.y = sp40[1];
+    }
+}
+
+// TODO: doesn't work with -Wa,--vr4300mul-off.
+void func_801087BC_2BFC2C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_s1 = arg1->unk3C;
+    omObjData* temp_s0 = arg0->unk00;
+    f32 var_f2;
+    f32 var_f2_2;
+    f32 var_f0_2;
+
+    if ((temp_s0->trans.y == 0.0f) && (temp_s1->unk04 & 8)) {
+        func_80109CC0_2C1130_tick_tock_hop(temp_s0->work[1], arg1);
+        return;
+    }
+    if (arg1->unk04 == 0) {
+        temp_s1->unk48 = -1.47f;
+        func_8010A9B0_2C1E20_tick_tock_hop(temp_s1->unk52, &temp_s0->trans.x, 0, &temp_s0->trans.z);
+        func_8010955C_2C09CC_tick_tock_hop(temp_s1, 6, 1);
+        func_8004AC10_4B810(0x3A, GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[temp_s0->work[0]]].chr);
+        arg1->unk04 = 1;
+    }
+    var_f2 = func_8001C7D0_1D3D0(temp_s0->model[0]);
+    if (var_f2 == -1.0f) {
+        var_f2 = HmfModelData[temp_s0->model[0]].unk40;
+    }
+    if (var_f2 > 5.0f && var_f2 < 7.0f && !(D_800CDA7C_CE67C[temp_s1->unk00] & 0x8000)) {
+        temp_s1->unk48 = -0.294f;
+    }
+    var_f2_2 = temp_s1->unk48;
+    if (var_f2_2 > 1.7f) {
+        var_f2_2 = 1.7f;
+    }
+    temp_s0->trans.y += var_f2_2 * var_f2_2 * (var_f2_2 >= 0.0f ? -35.0f : 35.0f);
+    temp_s1->unk48 += 0.15f;
+    var_f0_2 = 1.0f - temp_s0->trans.y / 300.0f;
+    if (var_f0_2 > 1.0f) {
+        var_f0_2 = 1.0f;
+    } else if (var_f0_2 < 0.5f) {
+        var_f0_2 = 0.5f;
+    }
+    Hu3DModelScaleSet(temp_s0->model[1], var_f0_2, var_f0_2, var_f0_2);
+    if (temp_s0->trans.y < 0.0f) {
+        temp_s0->trans.y = 0.0f;
+        temp_s1->unk04 &= ~2;
+        temp_s1->unk04 |= 1;
+        func_8010A9B0_2C1E20_tick_tock_hop(temp_s1->unk52, &temp_s0->trans.x, 0, &temp_s0->trans.z);
+        func_8004AC10_4B810(0x31, GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[temp_s0->work[0]]].chr);
+        func_8010955C_2C09CC_tick_tock_hop(temp_s1, 0x15, 1);
+        func_80109568_2C09D8_tick_tock_hop(temp_s1, 0);
+        func_80109CC0_2C1130_tick_tock_hop(temp_s0->work[1], arg1);
+    }
+}
+
+void func_80108B18_2BFF88_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_s1 = arg1->unk3C;
+    omObjData* temp_s0 = arg0->unk00;
+
+    if (!(temp_s1->unk04 & 0x18) && D_8010E6E0_2C5B50_tick_tock_hop->unk1C != 99 && temp_s1->unk40->unk00 != 0) {
+        func_8001C258_1CE58(temp_s0->model[7], 4, 0);
+        Hu3DModelPosSet(temp_s0->model[7], temp_s0->trans.x, 10.0f, temp_s0->trans.z);
+        func_8010955C_2C09CC_tick_tock_hop(temp_s1, 0xE, 1);
+        func_80109BE4_2C1054_tick_tock_hop(temp_s0->work[1], 0xFF, temp_s1, func_8010908C_2C04FC_tick_tock_hop, 0);
+        temp_s1->unk04 |= 8;
+        if (!(GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[temp_s0->work[0]]].stat & 1)) {
+            func_8004B25C_4BE5C(temp_s0->work[0], 2, 2, 0x14);
+        }
+    }
+}
+
+void func_80108C24_2C0094_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_s1 = arg1->unk3C;
+
+    D_800CDA7C_CE67C[temp_s1->unk00] = 0;
+    D_800CBB6E_CC76E[temp_s1->unk00] = 0;
+    D_800D20A1_D2CA1[temp_s1->unk00] = 0;
+    if (temp_s1->unk44->unk00 != 0) {
+        arg1->unk0D = 1;
+        arg1->unk0C++;
+        if (arg1->unk0C < 5) {
+            D_800CDA7C_CE67C[temp_s1->unk00] = 0x8000;
+        }
+    } else {
+        arg1->unk0C = 0;
+        if (arg1->unk0D != 0 && arg1->unk0E == 0) {
+            D_800CBB6E_CC76E[temp_s1->unk00] = HuMathSin(arg1->unk2C) * 70.0f;
+            D_800D20A1_D2CA1[temp_s1->unk00] = HuMathCos(arg1->unk2C) * 70.0f;
+            arg1->unk2C += 10.0f;
+            if (arg1->unk2C > 180.0f) {
+                arg1->unk2C = 180.0f;
+                arg1->unk0E = 1;
+            }
+        }
+    }
+}
+
+void func_80108D90_2C0200_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_s1 = arg1->unk3C;
+    omObjData* temp_s2 = arg0->unk00;
+    f32 var_f4;
+
+    arg1->unk22++;
+    if (arg1->unk22 < 40) {
+        return;
+    }
+    switch (arg1->unk04) {
+        case 0:
+            if (temp_s1->unk0A == 0 || temp_s1->unk0A == 2) {
+                arg1->unk1C[0] = 0;
+                arg1->unk2C = temp_s2->rot.y;
+                if (temp_s2->rot.y != 180.0f) {
+                    func_8010955C_2C09CC_tick_tock_hop(temp_s1, 2, 1);
+                    arg1->unk04 = 1;
+                } else {
+                    func_8010955C_2C09CC_tick_tock_hop(temp_s1, 0, 1);
+                    arg1->unk04 = 2;
+                }
+            }
+            break;
+        case 1:
+            var_f4 = arg1->unk1C[0] / 10.0f;
+            if (var_f4 > 1.0f) {
+                var_f4 = 1.0f;
+            }
+            temp_s2->rot.y = (180.0f - arg1->unk2C) * var_f4 + arg1->unk2C;
+            arg1->unk1C[0]++;
+            if (arg1->unk1C[0] >= 11) {
+                arg1->unk1C[0] = 0;
+                temp_s2->rot.y = 180.0f;
+                func_8010955C_2C09CC_tick_tock_hop(temp_s1, 0, 1);
+                arg1->unk04 = 2;
+            }
+            break;
+        default:
+            if (D_8010E6E0_2C5B50_tick_tock_hop->unk1C == 99) {
+                func_80109BE4_2C1054_tick_tock_hop(1, 0, NULL, func_80107140_2BE5B0_tick_tock_hop, 0);
+                func_80109CC0_2C1130_tick_tock_hop(temp_s2->work[1], arg1);
+            } else if (D_8010E4AA_2C591A_tick_tock_hop == 0) {
+                if (func_80037030_37C30() == 0) {
+                    D_8010E4AA_2C591A_tick_tock_hop = 1;
+                }
+            } else if (D_8010E4AA_2C591A_tick_tock_hop >= 2) {
+                if (func_80037030_37C30() == 0) {
+                    D_8010E4AA_2C591A_tick_tock_hop = 3;
+                }
+                if (D_8010E4AA_2C591A_tick_tock_hop == 3) {
+                    arg1->unk1C[0]++;
+                    if (arg1->unk1C[0] >= 15) {
+                        func_80109CC0_2C1130_tick_tock_hop(1, arg1);
+                        func_80109BE4_2C1054_tick_tock_hop(1, 0, NULL, func_80106D14_2BE184_tick_tock_hop, 0);
+                    }
+                }
+            } else {
+                arg1->unk1C[0]++;
+                if (arg1->unk1C[0] == 15) {
+                    HuAudSeqPlay(0x67);
+                    func_8010955C_2C09CC_tick_tock_hop(temp_s1, 0xD, 1);
+                    func_80036C4C_3784C(0x16, temp_s1->unk02);
+                    GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[temp_s2->work[0]]].bonusCoin += 10;
+                }
+                if (func_80037030_37C30() != 0) {
+                    arg1->unk1C[0] = 0;
+                    D_8010E4AA_2C591A_tick_tock_hop = 2;
+                }
+            }
+            break;
+    }
+}
+
+// TODO: doesn't work with -Wa,--vr4300mul-off.
+void func_8010908C_2C04FC_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    omObjData* temp_s1 = arg0->unk00;
+    f32 var_f2;
+    f32 var_f2_2;
+    f32 temp_fv0;
+    s16 temp_a1;
+
+    if (arg1->unk04 == 0) {
+        if (D_8010E6E0_2C5B50_tick_tock_hop->unk0C == 0.0f) {
+            if (D_8010E6E0_2C5B50_tick_tock_hop->unk08 < 0.0f) {
+                var_f2 = 1.0f;
+            } else {
+                var_f2 = -1.0f;
+            }
+        } else {
+            if (D_8010E6E0_2C5B50_tick_tock_hop->unk0C < 0.0f) {
+                var_f2 = -1.0f;
+            } else {
+                var_f2 = 1.0f;
+            }
+        }
+        arg1->unk2C = D_8010E6E0_2C5B50_tick_tock_hop->unk00 + var_f2 * 90.0f;
+        while (arg1->unk2C < 0.0f) {
+            arg1->unk2C += 360.0f;
+        }
+        while (arg1->unk2C > 360.0f) {
+            arg1->unk2C -= 360.0f;
+        }
+        arg1->unk30 = arg1->unk34 = HuMathSin(45.0f) * 60.000004f;
+        arg1->unk1C[0] = 0;
+        temp_a1 = D_8010E6E8_2C5B58_tick_tock_hop[temp_s1->work[0]];
+        func_8004AC98_4B898(GwPlayer[temp_a1].chr + 0x287, temp_a1);
+        func_8004AC98_4B898(0x4BE, temp_s1->work[0]);
+        arg1->unk04 = 1;
+    }
+    temp_s1->trans.y += arg1->unk30;
+    arg1->unk30 = arg1->unk34 - arg1->unk1C[0] * 2.45f;
+    arg1->unk1C[0]++;
+    temp_s1->trans.x += HuMathSin(arg1->unk2C) * 20.0f * 5.0f * 0.25f;
+    temp_s1->trans.z += HuMathCos(arg1->unk2C) * 20.0f * 5.0f * 0.25f;
+    temp_fv0 = temp_s1->trans.y;
+    var_f2_2 = 300.0f;
+    var_f2_2 = 1.0f - temp_fv0 / var_f2_2;
+    if (var_f2_2 > 1.0f) {
+        var_f2_2 = 1.0f;
+    } else if (var_f2_2 < 0.5f) {
+        var_f2_2 = 0.5f;
+    }
+    Hu3DModelScaleSet(temp_s1->model[1], var_f2_2, var_f2_2, var_f2_2);
+    HmfModelData[temp_s1->model[1]].unk1C = temp_s1->trans.x;
+    HmfModelData[temp_s1->model[1]].unk24 = temp_s1->trans.z;
+    if (temp_s1->trans.y < 10.0f) {
+        arg1->unk1C[0] = 0;
+        temp_s1->trans.y = 10.0f;
+        func_8001C258_1CE58(temp_s1->model[0], 4, 4);
+        func_8001C258_1CE58(temp_s1->model[1], 4, 4);
+        func_80109CC0_2C1130_tick_tock_hop(temp_s1->work[1], arg1);
+    }
+}
+
+void func_8010942C_2C089C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_s0 = arg1->unk3C;
+    omObjData* temp_s1 = arg0->unk00;
+    HmfModelData_Struct* temp_v1 = &HmfModelData[temp_s1->model[0]];
+    s16 temp_a2;
+
+    if (D_800CCF58_CDB58[temp_v1->unk02].unk02 - 1 <= temp_v1->unk40) {
+        temp_s0->unk08 = 1;
+    }
+    if (temp_s0->unk08 == 0) {
+        return;
+    }
+    func_800E5690_B8210_name_82(temp_s1, temp_s0->unk0A);
+    if (temp_s0->unk0A == 0xD) {
+        temp_a2 = D_8010E6E8_2C5B58_tick_tock_hop[temp_s1->work[0]];
+        func_80045F1C_46B1C(D_800A178C[GwPlayer[temp_a2].chr][0] | 0x30, -1, temp_a2);
+    }
+    temp_s0->unk08 = 0;
+    if (temp_s0->unk0C != -1) {
+        temp_s0->unk0A = temp_s0->unk0C;
+        temp_s0->unk0C = -1;
+    }
+}
+
+void func_8010955C_2C09CC_tick_tock_hop(D_8010E6E4_2C5B54_Struct* arg0, s32 arg1, s32 arg2) {
+    arg0->unk08 = arg2;
+    arg0->unk0A = arg1;
+}
+
+void func_80109568_2C09D8_tick_tock_hop(D_8010E6E4_2C5B54_Struct* arg0, s32 arg1) {
+    arg0->unk0C = arg1;
+}
+
+void func_80109570_2C09E0_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_t0 = arg1->unk3C;
+    omObjData* var_t1 = arg0->unk00;
+    D_8010E700_2C5B70_Unk60_Struct sp10 = { {
+        {  90.0f, 0.0f, 100.0f },
+        { -90.0f, 0.0f, 100.0f },
+        { -90.0f, 0.0f, 400.0f },
+        {  90.0f, 0.0f, 400.0f }
+    } };
+
+    switch (GwPlayer[D_8010E6E8_2C5B58_tick_tock_hop[var_t1->work[0]]].cpu_difficulty) {
+        case 0:
+            temp_t0->unk4C = 4;
+            temp_t0->unk4E = 0;
+            temp_t0->unk50 = 10;
+            break;
+        case 1:
+            temp_t0->unk4C = 3;
+            temp_t0->unk4E = 2;
+            temp_t0->unk50 = 20;
+            break;
+        case 2:
+            temp_t0->unk4C = 1;
+            temp_t0->unk4E = 10;
+            temp_t0->unk50 = 30;
+            break;
+        case 3:
+            temp_t0->unk4C = 0;
+            temp_t0->unk4E = 99;
+            temp_t0->unk50 = 40;
+            break;
+    }
+    func_8010D568_2C49D8_tick_tock_hop(D_8010E6E0_2C5B50_tick_tock_hop->unk1A, &sp10, 0.0f);
+    arg1->unk40 = func_80109700_2C0B70_tick_tock_hop;
+}
+
+void func_801096B0_2C0B20_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_a0 = arg1->unk3C;
+
+    if (temp_a0->unk24 != 99) {
+        D_800CDA7C_CE67C[temp_a0->unk00] = 0;
+        D_800CBB6E_CC76E[temp_a0->unk00] = 0;
+        D_800D20A1_D2CA1[temp_a0->unk00] = 0;
+    }
+}
+
+void func_80109700_2C0B70_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E6E4_2C5B54_Struct* temp_s3 = arg1->unk3C;
+    s32 temp_rand;
+
+    temp_s3->unk24 = 99;
+    D_800CDA7C_CE67C[temp_s3->unk00] = 0;
+    D_800CBB6E_CC76E[temp_s3->unk00] = 0;
+    D_800D20A1_D2CA1[temp_s3->unk00] = 0;
+    if (temp_s3->unk04 & 0x20) {
+        return;
+    }
+    if (arg1->unk0C == 0) {
+        if (temp_s3->unk44->unk00 != 0) {
+            if (D_8010E6E0_2C5B50_tick_tock_hop->unk1C > temp_s3->unk50) {
+                temp_rand = rand16();
+                if (temp_rand == (temp_rand / 6) * 6) {
+                    temp_s3->unk04 |= 0x20;
+                }
+            }
+            if (arg1->unk0D == 0) {
+                arg1->unk0C = 1;
+                arg1->unk0D = 1;
+            }
+        } else {
+            arg1->unk0D = 0;
+        }
+    }
+    if (arg1->unk0C == 1) {
+        arg1->unk1C[0]++;
+        if (arg1->unk1C[0] > rand16() % (temp_s3->unk4C + 1)) {
+            arg1->unk1C[0] = 0;
+            arg1->unk0C = 2;
+            if (rand16() % (temp_s3->unk4E + 1) != 0
+                && ABS(D_8010E6E0_2C5B50_tick_tock_hop->unk08 - D_8010E6E0_2C5B50_tick_tock_hop->unk0C) > 2.0f)
+            {
+                arg1->unk1C[1] = 1;
+            } else {
+                arg1->unk1C[1] = 6;
+            }
+        }
+    }
+    if (arg1->unk0C == 2) {
+        arg1->unk1C[0]++;
+        if (arg1->unk1C[0] <= arg1->unk1C[1]) {
+            D_800CDA7C_CE67C[temp_s3->unk00] = 0x8000;
+        } else {
+            arg1->unk1C[0] = 0;
+            arg1->unk0C = 0;
+        }
+    }
+}

--- a/src/overlays/ovl_39_tick_tock_hop/2C0E70.c
+++ b/src/overlays/ovl_39_tick_tock_hop/2C0E70.c
@@ -1,95 +1,1324 @@
-#include "common.h"
+#include "ovl_39.h"
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_80109A00_2C0E70_tick_tock_hop);
+#define M_ID(m, i, j) ((m)[(i) * 4 + (j)])
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_80109A94_2C0F04_tick_tock_hop);
+// EXTERN
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_80109BE4_2C1054_tick_tock_hop);
+typedef struct {
+    /* 0x00 */ void* unk00;
+    /* 0x04 */ u16 unk04;
+    /* 0x06 */ u16 unk06;
+    /* 0x08 */ char unk08[4];
+} Func_80055194_55D94_Unk00_Struct; // Size 0xC
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_80109CC0_2C1130_tick_tock_hop);
+typedef struct {
+    /* 0x00 */ Func_80055194_55D94_Unk00_Struct* unk00;
+    /* 0x04 */ char unk04[4];
+    /* 0x08 */ u8* unk08;
+    /* 0x0C */ s32 unk0C;
+    /* 0x10 */ s16 unk10;
+    /* 0x12 */ char unk12[6];
+    /* 0x18 */ u16 unk18;
+    /* 0x1A */ u16 unk1A;
+} Func_80055194_55D94_Struct; // Size unknown
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_80109D18_2C1188_tick_tock_hop);
+typedef struct {
+    /* 0x00 */ char unk00[0x10];
+    /* 0x10 */ s16 unk10;
+} Func_80055520_56120_Unk84_Struct;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_80109DCC_2C123C_tick_tock_hop);
+typedef struct {
+    /* 0x00 */ char unk00[0x84];
+    /* 0x84 */ Func_80055520_56120_Unk84_Struct* unk84;
+    /* 0x88 */ char unk88[8];
+    /* 0x90 */ s16 unk90;
+} Func_80055520_56120_Struct; // Size unknown
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_80109E2C_2C129C_tick_tock_hop);
+s32 SprAttrReset();
+s32 SprAttrSet();
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_80109F30_2C13A0_tick_tock_hop);
+void Hu3DModelRotSet(s16, f32, f32, f32);
+void* HuMemAlloc(s32);
+void* HuMemAllocTag(s32, s32);
+void HuMemFree(void*);
+void* memcpy(void*, const void*, unsigned int);
+void func_80017D24_18924(f32*, f32, f32, f32);
+s32 func_8001A894_1B494(s32, Gfx*, s32);
+void func_80054FF8_55BF8(s32, s32, s32);
+Func_80055194_55D94_Struct* func_80055194_55D94(s32);
+Func_80055520_56120_Struct* func_80055520_56120(s32, s32);
+f32 func_8008E108_8ED08(f32, f32);
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A07C_2C14EC_tick_tock_hop);
+extern s16 D_800CDD6A_CE96A;
+extern f32 D_800D138C_D1F8C[];
+extern u8 D_800D1FF0_D2BF0;
+extern u8 D_800D2008_D2C08;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A21C_2C168C_tick_tock_hop);
+// LOCAL
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A2B0_2C1720_tick_tock_hop);
+typedef struct {
+    /* 0x00 */ s8 unk00;
+    /* 0x04 */ s32 unk04;
+    /* 0x08 */ u8 unk08;
+    /* 0x0A */ s16 unk0A;
+    /* 0x0C */ s16 unk0C;
+    /* 0x0E */ s16 unk0E;
+    /* 0x10 */ f32* unk10;
+    /* 0x14 */ f32* unk14;
+    /* 0x18 */ f32* unk18;
+} D_8010E6F0_2C5B60_Struct; // Size 0x1C
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A300_2C1770_tick_tock_hop);
+typedef struct {
+    u8 r;
+    u8 g;
+    u8 b;
+    u8 a;
+} RGBA;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A3A8_2C1818_tick_tock_hop);
+void func_80109F30_2C13A0_tick_tock_hop(D_8010E6F4_2C5B64_Struct* arg0);
+s32 func_8010AD60_2C21D0_tick_tock_hop(Func_80055194_55D94_Struct* arg0, f32 arg1);
+s32 func_8010B4D0_2C2940_tick_tock_hop(Func_80055194_55D94_Struct* arg0, f32 arg1);
+void func_8010CCD4_2C4144_tick_tock_hop(u16 arg0, Func_80055194_55D94_Struct* arg1, u16 arg2);
+s16 func_8010CED8_2C4348_tick_tock_hop(Func_80055194_55D94_Struct* arg0, HmfModelData_Unk64_Struct* arg1, f32 arg2, u16 arg3, u16 arg4);
+void func_8010D5DC_2C4A4C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+f32 func_8010D938_2C4DA8_tick_tock_hop(D_8010E700_2C5B70_Struct* arg0, D_8010E700_2C5B70_Unk98_Struct* arg1, Vec* arg2, Vec* arg3);
+void func_8010DFB0_2C5420_tick_tock_hop(f32* arg0);
+void func_8010E2AC_2C571C_tick_tock_hop(f32 arg0, f32 arg1, f32 arg2, f32 arg3, f32 arg4, f32 arg5, f32* arg6);
+void func_8010E364_2C57D4_tick_tock_hop(Vec* arg0, s16 arg1, f32* arg2, Vec* arg3);
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A4A8_2C1918_tick_tock_hop);
+D_8010E6F0_2C5B60_Struct* D_8010E6F0_2C5B60_tick_tock_hop;
+D_8010E6F4_2C5B64_Struct* D_8010E6F4_2C5B64_tick_tock_hop;
+D_8010E6F8_2C5B68_Struct* D_8010E6F8_2C5B68_tick_tock_hop;
+D_8010E6FC_2C5B6C_Struct* D_8010E6FC_2C5B6C_tick_tock_hop;
+D_8010E700_2C5B70_Struct* D_8010E700_2C5B70_tick_tock_hop;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A620_2C1A90_tick_tock_hop);
+// TODO: the following arrays work but trigger multiple warnings: "missing braces around initializer"
+// Ideally we should use these and remove the u32 arrays below.
+/*
+Gfx D_8010E4B0_2C5920_tick_tock_hop[] = {
+    gsSPSegment(0x00, 0x00000000),
+    gsDPPipeSync(),
+    gsDPSetCycleType(G_CYC_1CYCLE),
+    gsDPPipelineMode(G_PM_1PRIMITIVE),
+    gsDPSetTextureLOD(G_TL_TILE),
+    gsDPSetTextureLUT(G_TT_NONE),
+    gsDPSetTextureDetail(G_TD_CLAMP),
+    gsDPSetTexturePersp(G_TP_NONE),
+    gsDPSetTileSize(G_TX_RENDERTILE, 0, 0, 0, 0),
+    gsDPSetTileSize(1, 0, 0, 0, 0),
+    gsDPSetTile(G_IM_FMT_RGBA, G_IM_SIZ_4b, 0, 0x0000, G_TX_RENDERTILE, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD),
+    gsDPSetTile(G_IM_FMT_RGBA, G_IM_SIZ_4b, 0, 0x0000, 1, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK, G_TX_NOLOD),
+    gsDPSetTextureFilter(G_TF_BILERP),
+    gsDPSetTextureConvert(G_TC_FILT),
+    gsDPSetCombineMode(G_CC_SHADE, G_CC_SHADE),
+    gsDPSetCombineKey(G_CK_NONE),
+    gsDPSetAlphaCompare(G_AC_NONE),
+    gsDPSetDepthSource(G_ZS_PIXEL),
+    gsDPSetRenderMode(G_RM_OPA_SURF, G_RM_OPA_SURF2),
+    gsDPNoOp(),
+    gsDPSetColorDither(G_CD_DISABLE),
+    gsDPPipeSync(),
+    gsSPEndDisplayList()
+};
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A788_2C1BF8_tick_tock_hop);
+Gfx D_8010E568_2C59D8_tick_tock_hop[] = {
+    gsSPClearGeometryMode(G_ZBUFFER | G_SHADE | G_CULL_BOTH | G_FOG | G_LIGHTING | G_TEXTURE_GEN | G_TEXTURE_GEN_LINEAR | G_LOD | G_SHADING_SMOOTH | G_CLIPPING | 0x0040F9FA),
+    gsSPTexture(0, 0, 0, G_TX_RENDERTILE, G_OFF),
+    gsSPSetGeometryMode(G_SHADE | G_SHADING_SMOOTH),
+    gsSPEndDisplayList()
+};
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A90C_2C1D7C_tick_tock_hop);
+Gfx D_8010E588_2C59F8_tick_tock_hop[] = {
+    gsSPDisplayList(D_8010E568_2C59D8_tick_tock_hop),
+    gsSPDisplayList(D_8010E4B0_2C5920_tick_tock_hop),
+    gsSPEndDisplayList()
+};
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010A9B0_2C1E20_tick_tock_hop);
+Gfx D_8010E5A0_2C5A10_tick_tock_hop[] = {
+    gsDPPipeSync(),
+    gsSPDisplayList(D_8010E588_2C59F8_tick_tock_hop),
+    gsDPSetCycleType(G_CYC_1CYCLE),
+    gsSPSetGeometryMode(G_ZBUFFER | G_CULL_BACK | G_LIGHTING | G_SHADING_SMOOTH),
+    gsDPSetBlendColor(0x00, 0x00, 0x00, 0x00),
+    gsDPSetPrimColor(0, 0, 0x00, 0x00, 0x00, 0xFF),
+    gsSPTexture(0xFFFF, 0xFFFF, 0, G_TX_RENDERTILE, G_ON),
+    gsSPEndDisplayList()
+};
+*/
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010AB40_2C1FB0_tick_tock_hop);
+u32 D_8010E4B0_2C5920_tick_tock_hop[] = {
+    0xDB060000, 0x00000000, 0xE7000000, 0x00000000, 0xE3000A01, 0x00000000, 0xE3000800, 0x00800000,
+    0xE3000F00, 0x00000000, 0xE3001001, 0x00000000, 0xE3000D01, 0x00000000, 0xE3000C00, 0x00000000,
+    0xF2000000, 0x00000000, 0xF2000000, 0x01000000, 0xF5000000, 0x00000000, 0xF5000000, 0x01000000,
+    0xE3001201, 0x00002000, 0xE3001402, 0x00000C00, 0xFCFFFFFF, 0xFFFE793C, 0xE3001700, 0x00000000,
+    0xE2001E01, 0x00000000, 0xE2001D00, 0x00000000, 0xE200001C, 0x0F0A4000, 0x00000000, 0x00000000,
+    0xE3001801, 0x000000C0, 0xE7000000, 0x00000000, 0xDF000000, 0x00000000, 0xD9000000, 0x00000000,
+    0xD7000000, 0x00000000, 0xD9FFFFFF, 0x00200004, 0xDF000000, 0x00000000, 0xDE000000, 0x8010E568,
+    0xDE000000, 0x8010E4B0, 0xDF000000, 0x00000000
+};
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010AB78_2C1FE8_tick_tock_hop);
+u32 D_8010E5A0_2C5A10_tick_tock_hop[] = {
+    0xE7000000, 0x00000000, 0xDE000000, 0x8010E588, 0xE3000A01, 0x00000000, 0xD9FFFFFF, 0x00220401,
+    0xF9000000, 0x00000000, 0xFA000000, 0x000000FF, 0xD7000002, 0xFFFFFFFF, 0xDF000000, 0x00000000
+};
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010ABCC_2C203C_tick_tock_hop);
+u8 D_8010E5E0_2C5A50_tick_tock_hop[] = { 0, 1, 0, 1, 2, 0, 2, 3, 0, 3, 0, 0, 0, 0, 0 };
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010AD60_2C21D0_tick_tock_hop);
+void func_80109A00_2C0E70_tick_tock_hop(void) {
+    D_8010E6F8_2C5B68_tick_tock_hop = HuMemAllocTag(8 * sizeof(*D_8010E6F8_2C5B68_tick_tock_hop), 31000);
+    memset(D_8010E6F8_2C5B68_tick_tock_hop, 0, 8 * sizeof(*D_8010E6F8_2C5B68_tick_tock_hop));
+    D_8010E6FC_2C5B6C_tick_tock_hop = HuMemAllocTag(8 * sizeof(*D_8010E6FC_2C5B6C_tick_tock_hop), 31000);
+    memset(D_8010E6FC_2C5B6C_tick_tock_hop, 0, 8 * sizeof(*D_8010E6FC_2C5B6C_tick_tock_hop));
+    D_8010E6F0_2C5B60_tick_tock_hop = HuMemAllocTag(2 * sizeof(*D_8010E6F0_2C5B60_tick_tock_hop), 31000);
+    memset(D_8010E6F0_2C5B60_tick_tock_hop, 0, 2 * sizeof(*D_8010E6F0_2C5B60_tick_tock_hop));
+    D_8010E6F4_2C5B64_tick_tock_hop = HuMemAllocTag(5 * sizeof(*D_8010E6F4_2C5B64_tick_tock_hop), 31000);
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010B4D0_2C2940_tick_tock_hop);
+D_8010E6F4_2C5B64_Struct* func_80109A94_2C0F04_tick_tock_hop(omObjData* arg0, s8 arg1, s16 arg2, s16 arg3) {
+    D_8010E6F4_2C5B64_Struct* temp_s2;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010C0E8_2C3558_tick_tock_hop);
+    if (arg1 >= 5) {
+        return NULL;
+    }
+    temp_s2 = &D_8010E6F4_2C5B64_tick_tock_hop[arg1];
+    if (arg3 != 0) {
+        temp_s2->unk04 = HuMemAllocTag(arg3 * sizeof(*temp_s2->unk04), 31000);
+        memset(temp_s2->unk04, 0, arg3 * sizeof(*temp_s2->unk04));
+        temp_s2->unk0C = HuMemAllocTag((arg3 + 1) * sizeof(*temp_s2->unk0C), 31000);
+    }
+    temp_s2->unk08 = arg3;
+    temp_s2->unk00 = HuMemAllocTag(sizeof(*temp_s2->unk00), 31000);
+    if (arg2 != 0) {
+        temp_s2->unk00->unk04 = HuMemAllocTag(arg2 * sizeof(*temp_s2->unk00->unk04), 31000);
+        memset(temp_s2->unk00->unk04, 0, arg2 * sizeof(*temp_s2->unk00->unk04));
+    }
+    temp_s2->unk00->unk08 = arg2;
+    temp_s2->unk10 = 1;
+    temp_s2->unk00->unk00 = arg0;
+    return temp_s2;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010CCD4_2C4144_tick_tock_hop);
+// 2C5B08 TODO: figure this out. File split?
+const u8 workaround[8] = { 0 };
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010CDA4_2C4214_tick_tock_hop);
+s16 func_80109BE4_2C1054_tick_tock_hop(s8 arg0, s32 arg1, D_8010E6E4_2C5B54_Struct* arg2, void (*arg3)(D_8010E6F4_2C5B64_Unk00_Struct*, D_8010E6F4_2C5B64_Unk04_Struct*), s8 arg4) {
+    D_8010E6F4_2C5B64_Struct* temp_t2 = &D_8010E6F4_2C5B64_tick_tock_hop[arg0];
+    D_8010E6F4_2C5B64_Unk04_Struct* var_v1 = temp_t2->unk04;
+    s16 temp_v0 = temp_t2->unk08;
+    s16 var_a0;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010CED8_2C4348_tick_tock_hop);
+    for (var_a0 = 0; var_a0 < temp_v0; var_a0++, var_v1++) {
+        if (var_v1->unk00 == 0) {
+            var_v1->unk00 = 1;
+            var_v1->unk08 = arg1;
+            var_v1->unk02 = var_a0;
+            var_v1->unk05 = arg4;
+            var_v1->unk04 = 0;
+            var_v1->unk3C = arg2;
+            var_v1->unk40 = arg3;
+            break;
+        }
+    }
+    if (var_a0 == temp_v0) {
+        osSyncPrintf("SetFunc Error %d!\n", arg0);
+        return -1;
+    }
+    temp_t2->unk10 = 1;
+    return var_a0;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010D2FC_2C476C_tick_tock_hop);
+void func_80109CC0_2C1130_tick_tock_hop(s8 arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    memset(arg1, 0, sizeof(*arg1));
+    D_8010E6F4_2C5B64_tick_tock_hop[arg0].unk10 = 1;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010D34C_2C47BC_tick_tock_hop);
+void func_80109D18_2C1188_tick_tock_hop(s8 arg0, s8 arg1) {
+    D_8010E6F4_2C5B64_Struct* temp_s2 = &D_8010E6F4_2C5B64_tick_tock_hop[arg0];
+    D_8010E6F4_2C5B64_Unk04_Struct* var_s0;
+    s16 var_s1;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010D49C_2C490C_tick_tock_hop);
+    var_s0 = temp_s2->unk04;
+    for (var_s1 = 0; var_s1 < temp_s2->unk08; var_s1++, var_s0++) {
+        if (var_s0->unk05 == arg1) {
+            func_80109CC0_2C1130_tick_tock_hop(arg0, var_s0);
+        }
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010D568_2C49D8_tick_tock_hop);
+void func_80109DCC_2C123C_tick_tock_hop(s8 arg0) {
+    D_8010E6F4_2C5B64_Struct* temp_s0 = &D_8010E6F4_2C5B64_tick_tock_hop[arg0];
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010D5DC_2C4A4C_tick_tock_hop);
+    memset(temp_s0->unk04, 0, temp_s0->unk08 * sizeof(*temp_s0->unk04));
+    temp_s0->unk10 = 1;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010D938_2C4DA8_tick_tock_hop);
+void func_80109E2C_2C129C_tick_tock_hop(s8 arg0) {
+    D_8010E6F4_2C5B64_Struct* temp_s1 = &D_8010E6F4_2C5B64_tick_tock_hop[arg0];
+    D_8010E6F4_2C5B64_Unk04_Struct* temp_a1;
+    s8 temp_s0;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010D99C_2C4E0C_tick_tock_hop);
+    if (temp_s1->unk10 != 0) {
+        func_80109F30_2C13A0_tick_tock_hop(temp_s1);
+    }
+    temp_s0 = 0;
+    while (temp_s1->unk0C[temp_s0].unk04 != -1) {
+        temp_s0 = temp_s1->unk0C[temp_s0].unk04;
+        temp_a1 = &temp_s1->unk04[temp_s1->unk0C[temp_s0].unk08];
+        if (temp_a1->unk00 != 0) {
+            temp_a1->unk40(temp_s1->unk00, temp_a1);
+        }
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010DA14_2C4E84_tick_tock_hop);
+void func_80109F30_2C13A0_tick_tock_hop(D_8010E6F4_2C5B64_Struct* arg0) {
+    D_8010E6F4_2C5B64_Unk0C_Struct* temp_a1 = arg0->unk0C;
+    D_8010E6F4_2C5B64_Unk04_Struct* var_t1 = arg0->unk04;
+    s16 var_a3;
+    s16 temp_a0;
+    s16 var_a2;
+    s16 var_t3;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010DA80_2C4EF0_tick_tock_hop);
+    temp_a1->unk04 = -1;
+    var_a3 = 1;
+    for (var_t3 = 0; var_t3 < arg0->unk08; var_t3++, var_t1++) {
+        if (var_t1->unk00 == 0) {
+            continue;
+        }
+        var_a2 = temp_a0 = 0;
+        while (temp_a1[temp_a0].unk04 != -1) {
+            temp_a0 = temp_a1[temp_a0].unk04;
+            if (temp_a1[temp_a0].unk00 < var_t1->unk08) {
+                var_a2 = temp_a0;
+                break;
+            }
+        }
+        temp_a1[var_a3].unk08 = var_t3;
+        temp_a1[var_a3].unk00 = var_t1->unk08;
+        temp_a1[var_a3].unk04 = temp_a1[var_a2].unk04;
+        temp_a1[var_a3].unk06 = var_a2;
+        temp_a1[var_a2].unk04 = var_a3;
+        if (temp_a1[var_a3].unk04 != -1) {
+            temp_a1[temp_a1[var_a3].unk04].unk06 = var_a3;
+        }
+        var_a3++;
+    }
+    arg0->unk10 = 0;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010DB8C_2C4FFC_tick_tock_hop);
+s16 func_8010A07C_2C14EC_tick_tock_hop(u16 arg0, s32 arg1, s32 arg2, u16 arg3, s32 arg4) {
+    D_8010E6F8_2C5B68_Struct* var_s0 = D_8010E6F8_2C5B68_tick_tock_hop;
+    Func_80055520_56120_Struct* temp_v0_2;
+    s16 var_s1;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010DD00_2C5170_tick_tock_hop);
+    for (var_s1 = 0; var_s1 < 8; var_s1++, var_s0++) {
+        if (var_s0->unk00 == 0) {
+            var_s0->unk02 = func_8000B838_C438((arg1 << 16) | arg2);
+            var_s0->unk01 = func_8005279C_5339C(1, 0);
+            var_s0->unk06 = 0xFF;
+            SprAttrReset(var_s0->unk01, 0, -1);
+            func_80055024_55C24(var_s0->unk01, 0, var_s0->unk02, 0);
+            SprAttrSet(var_s0->unk01, 0, arg4);
+            func_800550F4_55CF4(var_s0->unk01, 0, arg3);
+            SprPriSet(var_s0->unk01, 0, arg0);
+            func_80054FF8_55BF8(var_s0->unk01, 0, 0);
+            func_800550B4_55CB4(var_s0->unk01, 0, 1.0f);
+            SprScale(var_s0->unk01, 0, 1.0f, 1.0f);
+            func_80054904_55504(var_s0->unk01, 0, 100, 100);
+            temp_v0_2 = func_80055520_56120(var_s0->unk01, 0);
+            if (arg3 == 0) {
+                var_s0->unk04 = 99;
+            } else {
+                var_s0->unk04 = temp_v0_2->unk84->unk10;
+            }
+            var_s0->unk00 = 2;
+            func_8010A2B0_2C1720_tick_tock_hop(var_s1);
+            break;
+        }
+    }
+    return var_s1;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010DE30_2C52A0_tick_tock_hop);
+void func_8010A21C_2C168C_tick_tock_hop(s16 arg0, s32 arg1, s32 arg2) {
+    D_8010E6F8_2C5B68_Struct* temp_s0 = &D_8010E6F8_2C5B68_tick_tock_hop[arg0];
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010DFB0_2C5420_tick_tock_hop);
+    if (temp_s0->unk00 != 0) {
+        func_80054FF8_55BF8(temp_s0->unk01, 0, 0);
+        SprAttrReset(temp_s0->unk01, 0, 0x8000);
+        func_80054904_55504(temp_s0->unk01, 0, arg1, arg2);
+        temp_s0->unk00 = 2;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010E038_2C54A8_tick_tock_hop);
+void func_8010A2B0_2C1720_tick_tock_hop(s16 arg0) {
+    D_8010E6F8_2C5B68_Struct* temp_s0 = &D_8010E6F8_2C5B68_tick_tock_hop[arg0];
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010E090_2C5500_tick_tock_hop);
+    if (temp_s0->unk00 != 0) {
+        SprAttrSet(temp_s0->unk01, 0, 0x8000);
+        temp_s0->unk00 = 1;
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010E0F8_2C5568_tick_tock_hop);
+void func_8010A300_2C1770_tick_tock_hop(void) {
+    D_8010E6F8_2C5B68_Struct* var_s0;
+    s16 var_s1;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010E160_2C55D0_tick_tock_hop);
+    var_s0 = D_8010E6F8_2C5B68_tick_tock_hop;
+    for (var_s1 = 0; var_s1 < 8; var_s1++, var_s0++) {
+        if (var_s0->unk00 == 2 && func_80055520_56120(var_s0->unk01, 0)->unk90 + 1 >= var_s0->unk04) {
+            SprAttrSet(var_s0->unk01, 0, 0x8000);
+            func_80054FF8_55BF8(var_s0->unk01, 0, 0);
+        }
+    }
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010E214_2C5684_tick_tock_hop);
+s32 func_8010A3A8_2C1818_tick_tock_hop(s32 arg0, s32 arg1, f32 arg2, s32 arg3, s32 arg4) {
+    D_8010E6FC_2C5B6C_Struct* var_s0;
+    HmfModelData_Struct* temp_v0_3;
+    s16 var_s1;
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010E2AC_2C571C_tick_tock_hop);
+    var_s0 = D_8010E6FC_2C5B6C_tick_tock_hop;
+    for (var_s1 = 0; var_s1 < 8; var_s1++, var_s0++) {
+        if (var_s0->unk00 == 0) {
+            var_s0->unk0A = func_8000B108_BD08((arg0 << 16) | arg1, arg4);
+            func_8001C258_1CE58(var_s0->unk0A, 4, 4);
+            temp_v0_3 = &HmfModelData[var_s0->unk0A];
+            temp_v0_3->unk40 = 0.0f;
+            temp_v0_3->unk44 = 0.0f;
+            if (temp_v0_3->unk64->unk98 != NULL) {
+                temp_v0_3->unk64->unk98->unk08 = 0;
+            }
+            var_s0->unk04 = arg3;
+            var_s0->unk0C = arg2;
+            var_s0->unk08 = -1;
+            var_s0->unk00 = 1;
+            break;
+        }
+    }
+    return var_s1;
+}
 
-INCLUDE_ASM("asm/nonmatchings/overlays/ovl_39_tick_tock_hop/2C0E70", func_8010E364_2C57D4_tick_tock_hop);
+s32 func_8010A4A8_2C1918_tick_tock_hop(s16 arg0, f32 arg1, f32 arg2, f32 arg3, f32 arg4, f32 arg5, f32 arg6, f32 arg7, f32 arg8) {
+    D_8010E6FC_2C5B6C_Struct* temp_s0;
+    HmfModelData_Struct* temp_s1;
+
+    if (arg0 >= 8) {
+        return 0;
+    }
+    if (D_8010E6FC_2C5B6C_tick_tock_hop[arg0].unk00 == 0) {
+        return 0;
+    }
+    temp_s0 = &D_8010E6FC_2C5B6C_tick_tock_hop[arg0];
+    temp_s1 = &HmfModelData[temp_s0->unk0A];
+    if ((temp_s1->unk18 & 4) && temp_s0->unk08 == -1) {
+        Hu3DModelPosSet(temp_s0->unk0A, arg1, arg2, arg3);
+        Hu3DModelRotSet(temp_s0->unk0A, arg4, arg5, arg6);
+        Hu3DModelScaleSet(temp_s0->unk0A, arg7, arg7, arg7);
+        if (arg8 == 0.0f) {
+            func_8001C258_1CE58(temp_s0->unk0A, 4, 0);
+            temp_s0->unk08 = 1;
+            temp_s0->unk14 = 0.0f;
+            temp_s0->unk10 = 0.0f;
+            temp_s1->unk44 = temp_s0->unk0C;
+        } else {
+            temp_s0->unk08 = 0;
+            temp_s0->unk14 = arg8;
+            temp_s0->unk10 = 0.0f;
+        }
+        return 1;
+    }
+    return 0;
+}
+
+void func_8010A620_2C1A90_tick_tock_hop(void) {
+    D_8010E6FC_2C5B6C_Struct* var_s0;
+    HmfModelData_Struct* temp_s1;
+    s16 var_s2;
+
+    var_s0 = D_8010E6FC_2C5B6C_tick_tock_hop;
+    for (var_s2 = 0; var_s2 < 8; var_s2++, var_s0++) {
+        if (var_s0->unk00 == 0 || var_s0->unk08 == -1) {
+            continue;
+        }
+        temp_s1 = &HmfModelData[var_s0->unk0A];
+        if (var_s0->unk08 != 0) {
+            if (D_800CCF58_CDB58[temp_s1->unk02].unk02 <= temp_s1->unk40) {
+                temp_s1->unk40 = 0.0f;
+                if (temp_s1->unk64->unk98 != NULL) {
+                    temp_s1->unk64->unk98->unk08 = 0;
+                }
+                if (!(var_s0->unk04 & 1)) {
+                    func_8001C258_1CE58(var_s0->unk0A, 4, 4);
+                    var_s0->unk08 = -1;
+                    temp_s1->unk44 = 0;
+                }
+            }
+        } else if (var_s0->unk14 <= var_s0->unk10++) {
+            func_8001C258_1CE58(var_s0->unk0A, 4, 0);
+            var_s0->unk08 = 1;
+            temp_s1->unk44 = var_s0->unk0C;
+        }
+    }
+}
+
+s32 func_8010A788_2C1BF8_tick_tock_hop(s32 arg0, s32 arg1, s32 arg2) {
+    D_8010E6F0_2C5B60_Struct* var_s0;
+    s16 temp_v0_2;
+    s16 var_s3;
+
+    var_s0 = D_8010E6F0_2C5B60_tick_tock_hop;
+    for (var_s3 = 0; var_s3 < 2; var_s3++, var_s0++) {
+        if (var_s0->unk00 == 0) {
+            temp_v0_2 = func_8000B838_C438((arg0 << 16) | arg1);
+            var_s0->unk08 = temp_v0_2;
+            if (arg2 & 1) {
+                var_s0->unk0A = func_8010B4D0_2C2940_tick_tock_hop(func_80055194_55D94(temp_v0_2), 1.0f);
+            } else {
+                var_s0->unk0A = func_8010AD60_2C21D0_tick_tock_hop(func_80055194_55D94(temp_v0_2), 1.0f);
+            }
+            if (arg2 & 8) {
+                func_8001C258_1CE58(var_s0->unk0A, 4, 4);
+            }
+            var_s0->unk10 = &HmfModelData[var_s0->unk0A].unk1C;
+            var_s0->unk14 = &HmfModelData[var_s0->unk0A].unk20;
+            var_s0->unk18 = &HmfModelData[var_s0->unk0A].unk24;
+            var_s0->unk04 = arg2;
+            var_s0->unk0C = func_80055194_55D94(temp_v0_2)->unk10;
+            var_s0->unk0E = 0;
+            var_s0->unk00 = 1;
+            break;
+        }
+    }
+    if (var_s3 == 2) {
+        osSyncPrintf("SetBill Error! \n");
+    }
+    return var_s3;
+}
+
+void func_8010A90C_2C1D7C_tick_tock_hop(s16 arg0, f32 arg1, f32 arg2, f32 arg3) {
+    if (arg0 < 2) {
+        HmfModelData_Struct* temp_v0 = &HmfModelData[D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk0A];
+
+        temp_v0->unk1C = arg1;
+        temp_v0->unk20 = arg2;
+        temp_v0->unk24 = arg3;
+        func_8001C258_1CE58(D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk0A, 4, 0);
+        D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk04 &= ~0x18;
+    }
+}
+
+void func_8010A9B0_2C1E20_tick_tock_hop(s16 arg0, f32* arg1, f32* arg2, f32* arg3) {
+    HmfModelData_Struct* temp_t1;
+    D_8010E6F0_2C5B60_Struct* temp_s0;
+
+    if (arg0 >= 2) {
+        return;
+    }
+    temp_t1 = &HmfModelData[D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk0A];
+    if (arg1 != NULL) {
+        D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk10 = arg1;
+    } else {
+        D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk10 = &temp_t1->unk1C;
+    }
+    if (arg2 != NULL) {
+        D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk14 = arg2;
+    } else {
+        D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk14 = &temp_t1->unk20;
+    }
+    if (arg3 != NULL) {
+        D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk18 = arg3;
+    } else {
+        D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk18 = &temp_t1->unk24;
+    }
+    func_8001C258_1CE58(D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk0A, 4, 0);
+    temp_s0 = &D_8010E6F0_2C5B60_tick_tock_hop[arg0];
+    temp_s0->unk04 &= ~0x18;
+    temp_s0->unk04 |= 0x10;
+}
+
+D_8010E6F0_2C5B60_Struct* func_8010AB40_2C1FB0_tick_tock_hop(s16 arg0) {
+    if (arg0 >= 2) {
+        return NULL;
+    }
+    return &D_8010E6F0_2C5B60_tick_tock_hop[arg0];
+}
+
+HmfModelData_Struct* func_8010AB78_2C1FE8_tick_tock_hop(s16 arg0) {
+    if (arg0 >= 2) {
+        return NULL;
+    }
+    return &HmfModelData[D_8010E6F0_2C5B60_tick_tock_hop[arg0].unk0A];
+}
+
+void func_8010ABCC_2C203C_tick_tock_hop(void) {
+    D_8010E6F0_2C5B60_Struct* var_s1;
+    HmfModelData_Struct* temp_s0;
+    s16 var_s2;
+
+    var_s1 = D_8010E6F0_2C5B60_tick_tock_hop;
+    for (var_s2 = 0; var_s2 < 2; var_s2++, var_s1++) {
+        if (var_s1->unk00 == 0 || (var_s1->unk04 & 8)) {
+            continue;
+        }
+        temp_s0 = &HmfModelData[var_s1->unk0A];
+        if (var_s1->unk04 & 0x10) {
+            temp_s0->unk1C = *var_s1->unk10;
+            temp_s0->unk20 = *var_s1->unk14;
+            temp_s0->unk24 = *var_s1->unk18;
+        }
+        temp_s0->unk28 = D_800D138C_D1F8C[0];
+        temp_s0->unk2C = D_800D138C_D1F8C[1];
+        func_8010DFB0_2C5420_tick_tock_hop(temp_s0->unk74);
+        func_80017D24_18924(temp_s0->unk74, 0.0f, 0.0f, D_800D138C_D1F8C[2]);
+        if (var_s1->unk04 & 1) {
+            if (var_s1->unk04 & 2) {
+                func_8010CCD4_2C4144_tick_tock_hop(var_s1->unk0A, func_80055194_55D94(var_s1->unk08), var_s1->unk0E);
+                var_s1->unk0E++;
+                if (var_s1->unk0E >= var_s1->unk0C) {
+                    if (var_s1->unk04 & 4) {
+                        var_s1->unk0E = 0;
+                    } else {
+                        var_s1->unk0E = 0;
+                        var_s1->unk04 |= 8;
+                        func_8001C258_1CE58(var_s1->unk0A, 4, 4);
+                    }
+                }
+            }
+        }
+    }
+}
+
+s32 func_8010AD60_2C21D0_tick_tock_hop(Func_80055194_55D94_Struct* arg0, f32 arg1) {
+    HmfModelData_Unk64_Struct* temp_s6;
+    Gfx* temp_v0_0;
+    Gfx* temp_v0;
+    u32 temp_s5;
+    s32 temp_s0;
+    s32 var_s7;
+    s16 temp_v0_2;
+    s16 var_s4;
+
+    temp_v0_0 = temp_v0 = HuMemAlloc(0x10000);
+    temp_v0_2 = func_8001A894_1B494(0x4C1, temp_v0_0, 4);
+    temp_s6 = HmfModelData[temp_v0_2].unk64;
+    temp_s6->unk60->unk50 |= 0x01010000;
+    temp_s5 = func_8010CED8_2C4348_tick_tock_hop(arg0, temp_s6, 1.0f, 0, 0x64);
+    gSPDisplayList(temp_v0++, osVirtualToPhysical(D_8010E5A0_2C5A10_tick_tock_hop));
+    gDPPipeSync(temp_v0++);
+    gDPSetCycleType(temp_v0++, G_CYC_1CYCLE);
+    gDPPipeSync(temp_v0++);
+    gSPClearGeometryMode(temp_v0++, G_CULL_BOTH | G_LIGHTING);
+    gSPSetGeometryMode(temp_v0++, G_ZBUFFER | G_SHADE | G_CULL_FRONT | G_TEXTURE_GEN_LINEAR | G_SHADING_SMOOTH);
+    gDPSetColorDither(temp_v0++, G_CD_NOISE);
+    gDPSetTexturePersp(temp_v0++, G_TP_NONE);
+    gDPSetTextureFilter(temp_v0++, G_TF_BILERP);
+    gDPSetTextureConvert(temp_v0++, G_TC_FILT);
+    gDPSetAlphaDither(temp_v0++, G_AD_PATTERN);
+    gDPSetAlphaCompare(temp_v0++, G_AC_NONE);
+    gDPSetBlendColor(temp_v0++, 0x01, 0x01, 0x01, 0x01);
+    gDPPipeSync(temp_v0++);
+    gDPSetRenderMode(temp_v0++, G_RM_ZB_XLU_SURF, G_RM_NOOP2);
+    gDPSetCombineLERP(temp_v0++, 0, 0, 0, TEXEL0, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, TEXEL0, 0, PRIMITIVE, 0);
+    gDPSetPrimColor(temp_v0++, 0, 0, 0xFF, 0xFF, 0xFF, arg1 * 255.0f);
+    gDPPipeSync(temp_v0++);
+    gSPTexture(temp_v0++, 0x8000, 0x8000, 0, G_TX_RENDERTILE, G_ON);
+    gDPSetTexturePersp(temp_v0++, G_TP_PERSP);
+    if (arg0->unk1A >= 2) {
+        gDPSetTextureLUT(temp_v0++, G_TT_RGBA16);
+        var_s7 = 0x800;
+        if (arg0->unk18 == 4) {
+            gDPLoadTLUT_pal16(temp_v0++, 0, arg0->unk0C);
+        } else {
+            gDPLoadTLUT_pal256(temp_v0++, arg0->unk0C);
+        }
+    } else {
+        gDPSetTextureLUT(temp_v0++, G_TT_NONE);
+        var_s7 = 0x1000;
+    }
+    gDPPipeSync(temp_v0++);
+    for (var_s4 = 0; var_s4 < temp_s5; var_s4++) {
+        gSPSegment(temp_v0++, 0x02, osVirtualToPhysical(arg0->unk08 + var_s7 * var_s4));
+        gDPLoadTextureBlock(temp_v0++, 0x02000000, G_IM_FMT_CI, G_IM_SIZ_8b,
+            arg0->unk00->unk04, arg0->unk00->unk06 / temp_s5, 0,
+            G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+            G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+        gDPPipeSync(temp_v0++);
+        gSPSegment(temp_v0++, 0x01, osVirtualToPhysical(&temp_s6->unk44[0][var_s4 * 4]));
+        gSPVertex(temp_v0++, 0x01000000, 4, 0);
+        gSP2Triangles(temp_v0++, 0, 1, 2, 0, 1, 3, 2, 0);
+    }
+    gSPClearGeometryMode(temp_v0++, G_ZBUFFER | G_SHADE | G_CULL_BOTH | G_FOG | G_LIGHTING | G_TEXTURE_GEN | G_TEXTURE_GEN_LINEAR | G_LOD | G_SHADING_SMOOTH | G_CLIPPING | 0x0040F9FA);
+    gSPSetGeometryMode(temp_v0++, G_ZBUFFER | G_SHADE | G_CULL_BACK | G_TEXTURE_GEN_LINEAR);
+    gDPPipeSync(temp_v0++);
+    gSPEndDisplayList(temp_v0++);
+    temp_s0 = (u32) temp_v0 - (u32) temp_v0_0;
+    temp_s6->unk3C->unk00 = HuMemAllocTag(temp_s0, temp_s6->unk0E);
+    bcopy(temp_v0_0, temp_s6->unk3C->unk00, temp_s0);
+    HuMemFree(temp_v0_0);
+    return temp_v0_2;
+}
+
+s32 func_8010B4D0_2C2940_tick_tock_hop(Func_80055194_55D94_Struct* arg0, f32 arg1) {
+    HmfModelData_Unk64_Struct* temp_s4;
+    Gfx* temp_v0_0;
+    Gfx* temp_v0;
+    s32 temp_s0;
+    s16 temp_v0_2;
+    s16 var_a2;
+    s16 var_s1;
+
+    temp_v0_0 = temp_v0 = HuMemAlloc(0x10000);
+    temp_v0_2 = func_8001A894_1B494(0x4C1, temp_v0_0, 4);
+    temp_s4 = HmfModelData[temp_v0_2].unk64;
+    temp_s4->unk60->unk50 |= 0x01010000;
+    HuMemFree(temp_s4->unk3C);
+    temp_s4->unk3C = HuMemAllocTag(0x14, D_800CDD6A_CE96A);
+    func_8010CED8_2C4348_tick_tock_hop(arg0, temp_s4, 1.0f, 0, 0x1E);
+    gSPDisplayList(temp_v0++, osVirtualToPhysical(D_8010E5A0_2C5A10_tick_tock_hop));
+    gDPPipeSync(temp_v0++);
+    gDPSetCycleType(temp_v0++, G_CYC_1CYCLE);
+    gDPPipeSync(temp_v0++);
+    gSPClearGeometryMode(temp_v0++, G_CULL_BOTH | G_LIGHTING);
+    gSPSetGeometryMode(temp_v0++, G_ZBUFFER | G_CULL_FRONT | G_TEXTURE_GEN_LINEAR);
+    gDPSetColorDither(temp_v0++, G_CD_NOISE);
+    gDPSetTexturePersp(temp_v0++, G_TP_NONE);
+    gDPSetTextureFilter(temp_v0++, G_TF_BILERP);
+    gDPSetTextureConvert(temp_v0++, G_TC_FILT);
+    gDPSetAlphaDither(temp_v0++, G_AD_PATTERN);
+    gDPSetAlphaCompare(temp_v0++, G_AC_NONE);
+    gDPSetBlendColor(temp_v0++, 0x01, 0x01, 0x01, 0x01);
+    gDPPipeSync(temp_v0++);
+    gDPSetRenderMode(temp_v0++, G_RM_ZB_XLU_SURF, G_RM_NOOP2);
+    if (arg0->unk1A >= 2) {
+        gDPSetCombineLERP(temp_v0++, 0, 0, 0, TEXEL0, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, TEXEL0, 0, PRIMITIVE, 0);
+        gDPSetPrimColor(temp_v0++, 0, 0, 0xFF, 0xFF, 0xFF, arg1 * 255.0f);
+    } else {
+        if (arg0->unk18 & 0x8000) {
+            gDPSetCombineLERP(temp_v0++, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0);
+        } else {
+            gDPSetCombineLERP(temp_v0++, 0, 0, 0, TEXEL0, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, TEXEL0, 0, PRIMITIVE, 0);
+        }
+        gDPSetPrimColor(temp_v0++, 0, 0, 0xFF, 0xFF, 0xFF, arg1 * 255.0f);
+    }
+    gDPPipeSync(temp_v0++);
+    gSPTexture(temp_v0++, 0x8000, 0x8000, 0, G_TX_RENDERTILE, G_ON);
+    gDPSetTexturePersp(temp_v0++, G_TP_PERSP);
+    if (arg0->unk1A >= 2) {
+        gDPSetTextureLUT(temp_v0++, G_TT_RGBA16);
+        if (arg0->unk18 == 4) {
+            gDPLoadTLUT_pal16(temp_v0++, 0, arg0->unk0C);
+        } else {
+            gDPLoadTLUT_pal256(temp_v0++, arg0->unk0C);
+        }
+        gDPPipeSync(temp_v0++);
+        var_a2 = 2;
+    } else {
+        gDPSetTextureLUT(temp_v0++, G_TT_NONE);
+        gDPPipeSync(temp_v0++);
+        var_a2 = (arg0->unk18 & 0x8000) ? 4 : 0;
+    }
+    switch (arg0->unk18 & 0xFFF) {
+        case 4:
+            gDPLoadTextureBlock_4b(temp_v0++, 0x02000000, var_a2,
+                arg0->unk00->unk04, arg0->unk00->unk06, 0,
+                G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+                G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            break;
+        case 8:
+            gDPLoadTextureBlock(temp_v0++, 0x02000000, var_a2, G_IM_SIZ_8b,
+                arg0->unk00->unk04, arg0->unk00->unk06, 0,
+                G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+                G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            break;
+        case 16:
+            gDPLoadTextureBlock(temp_v0++, 0x02000000, var_a2, G_IM_SIZ_16b,
+                arg0->unk00->unk04, arg0->unk00->unk06, 0,
+                G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+                G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            break;
+    }
+    gDPPipeSync(temp_v0++);
+    gSPSegment(temp_v0++, 0x01, osVirtualToPhysical(temp_s4->unk44[0]));
+    gSPVertex(temp_v0++, 0x01000000, 4, 0);
+    gSP2Triangles(temp_v0++, 0, 1, 2, 0, 1, 3, 2, 0);
+    gSPClearGeometryMode(temp_v0++, G_ZBUFFER | G_SHADE | G_CULL_BOTH | G_FOG | G_LIGHTING | G_TEXTURE_GEN | G_TEXTURE_GEN_LINEAR | G_LOD | G_SHADING_SMOOTH | G_CLIPPING | 0x0040F9FA);
+    gSPSetGeometryMode(temp_v0++, G_ZBUFFER | G_SHADE | G_CULL_BACK | G_TEXTURE_GEN_LINEAR);
+    gDPPipeSync(temp_v0++);
+    gSPEndDisplayList(temp_v0++);
+    temp_s0 = (u32) temp_v0 - (u32) temp_v0_0;
+    temp_s4->unk3C->unk00 = temp_s4->unk3C->unk10 = HuMemAllocTag(temp_s0, temp_s4->unk0E);
+    bcopy(temp_v0_0, temp_s4->unk3C->unk00, temp_s0);
+    HuMemFree(temp_v0_0);
+    for (var_s1 = 0; var_s1 < D_800D1FF0_D2BF0; var_s1++) {
+        temp_v0 = *(temp_s4->unk3C->unk04 + var_s1) = HuMemAllocTag(0x100, temp_s4->unk0E);
+        gDPPipeSync(temp_v0++);
+        gSPSegment(temp_v0++, 0x02, osVirtualToPhysical(arg0->unk00->unk00));
+        gSPDisplayList(temp_v0++, osVirtualToPhysical(temp_s4->unk3C->unk10));
+        gSPEndDisplayList(temp_v0++);
+    }
+    temp_s4->unk3C->unk00 = temp_s4->unk3C->unk04[D_800D2008_D2C08];
+    return temp_v0_2;
+}
+
+s16 func_8010C0E8_2C3558_tick_tock_hop(Func_80055194_55D94_Struct* arg0, RGBA* arg1) {
+    HmfModelData_Unk64_Struct* temp_s4;
+    Gfx* temp_v0_0;
+    Gfx* temp_v0_2;
+    s32 temp_s0;
+    s32 temp_v0;
+    s32 var_a2;
+    s32 var_s1;
+
+    temp_v0_0 = temp_v0_2 = HuMemAlloc(0x10000);
+    temp_v0 = func_8001A894_1B494(0x8C1, temp_v0_0, 4);
+    temp_s4 = HmfModelData[temp_v0].unk64;
+    temp_s4->unk60->unk50 |= 0x01010000;
+    HuMemFree(temp_s4->unk3C);
+    temp_s4->unk3C = HuMemAllocTag(0x18, D_800CDD6A_CE96A);
+    func_8010CED8_2C4348_tick_tock_hop(arg0, temp_s4, 1.0f, 0, 0);
+    gSPDisplayList(temp_v0_2++, osVirtualToPhysical(D_8010E5A0_2C5A10_tick_tock_hop));
+    gDPPipeSync(temp_v0_2++);
+    gDPSetCycleType(temp_v0_2++, G_CYC_1CYCLE);
+    gDPPipeSync(temp_v0_2++);
+    gSPClearGeometryMode(temp_v0_2++, G_CULL_BOTH | G_LIGHTING);
+    gSPSetGeometryMode(temp_v0_2++, G_ZBUFFER | G_CULL_FRONT | G_TEXTURE_GEN_LINEAR);
+    gDPSetColorDither(temp_v0_2++, G_CD_NOISE);
+    gDPSetTexturePersp(temp_v0_2++, G_TP_NONE);
+    gDPSetTextureFilter(temp_v0_2++, G_TF_BILERP);
+    gDPSetTextureConvert(temp_v0_2++, G_TC_FILT);
+    gDPSetAlphaDither(temp_v0_2++, G_AD_PATTERN);
+    gDPSetAlphaCompare(temp_v0_2++, G_AC_NONE);
+    gDPSetBlendColor(temp_v0_2++, 0x01, 0x01, 0x01, 0x01);
+    gDPPipeSync(temp_v0_2++);
+    gDPSetRenderMode(temp_v0_2++, G_RM_ZB_XLU_SURF, G_RM_NOOP2);
+    if (arg0->unk18 & 0x8000) {
+        gDPSetCombineLERP(temp_v0_2++, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, PRIMITIVE, TEXEL0, 0, PRIMITIVE, 0);
+    } else {
+        gDPSetCombineLERP(temp_v0_2++, 0, 0, 0, TEXEL0, TEXEL0, 0, PRIMITIVE, 0, 0, 0, 0, TEXEL0, TEXEL0, 0, PRIMITIVE, 0);
+    }
+    gDPPipeSync(temp_v0_2++);
+    gSPEndDisplayList(temp_v0_2++);
+    temp_s0 = (u32) temp_v0_2 - (u32) temp_v0_0;
+    temp_s4->unk3C->unk10 = HuMemAllocTag(temp_s0, temp_s4->unk0E);
+    bcopy(temp_v0_0, temp_s4->unk3C->unk10, temp_s0);
+    HuMemFree(temp_v0_0);
+    temp_v0_0 = temp_v0_2 = HuMemAlloc(0x10000);
+    gSPTexture(temp_v0_2++, 0x8000, 0x8000, 0, G_TX_RENDERTILE, G_ON);
+    gDPSetTexturePersp(temp_v0_2++, G_TP_PERSP);
+    if (arg0->unk1A >= 2) {
+        gDPSetTextureLUT(temp_v0_2++, G_TT_RGBA16);
+        if (arg0->unk18 == 4) {
+            gDPLoadTLUT_pal16(temp_v0_2++, 0, arg0->unk0C);
+        } else {
+            gDPLoadTLUT_pal256(temp_v0_2++, arg0->unk0C);
+        }
+        gDPPipeSync(temp_v0_2++);
+        var_a2 = 2;
+    } else {
+        gDPSetTextureLUT(temp_v0_2++, G_TT_NONE);
+        gDPPipeSync(temp_v0_2++);
+        var_a2 = (arg0->unk18 & 0x8000) ? 4 : 0;
+    }
+    switch (arg0->unk18 & 0xFFF) {
+        case 4:
+            gDPLoadTextureBlock_4b(temp_v0_2++, 0x02000000, var_a2,
+                arg0->unk00->unk04, arg0->unk00->unk06, 0,
+                G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+                G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            break;
+        case 8:
+            gDPLoadTextureBlock(temp_v0_2++, 0x02000000, var_a2, G_IM_SIZ_8b,
+                arg0->unk00->unk04, arg0->unk00->unk06, 0,
+                G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+                G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            break;
+        case 16:
+            gDPLoadTextureBlock(temp_v0_2++, 0x02000000, var_a2, G_IM_SIZ_16b,
+                arg0->unk00->unk04, arg0->unk00->unk06, 0,
+                G_TX_NOMIRROR | G_TX_CLAMP, G_TX_NOMIRROR | G_TX_CLAMP,
+                G_TX_NOMASK, G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
+            break;
+    }
+    gDPPipeSync(temp_v0_2++);
+    gSPSegment(temp_v0_2++, 0x01, osVirtualToPhysical(temp_s4->unk44[0]));
+    gSPVertex(temp_v0_2++, 0x01000000, 4, 0);
+    gSP2Triangles(temp_v0_2++, 0, 1, 2, 0, 1, 3, 2, 0);
+    gSPClearGeometryMode(temp_v0_2++, G_ZBUFFER | G_SHADE | G_CULL_BOTH | G_FOG | G_LIGHTING | G_TEXTURE_GEN | G_TEXTURE_GEN_LINEAR | G_LOD | G_SHADING_SMOOTH | G_CLIPPING | 0x0040F9FA);
+    gSPSetGeometryMode(temp_v0_2++, G_ZBUFFER | G_SHADE | G_CULL_BACK | G_TEXTURE_GEN_LINEAR);
+    gDPPipeSync(temp_v0_2++);
+    gSPEndDisplayList(temp_v0_2++);
+    temp_s0 = (u32) temp_v0_2 - (u32) temp_v0_0;
+    temp_s4->unk3C->unk14 = HuMemAllocTag(temp_s0, temp_s4->unk0E);
+    bcopy(temp_v0_0, temp_s4->unk3C->unk14, temp_s0);
+    HuMemFree(temp_v0_0);
+    for (var_s1 = 0; var_s1 < D_800D1FF0_D2BF0; var_s1++) {
+        temp_v0_2 = temp_s4->unk3C->unk04[var_s1] = HuMemAllocTag(0x100, temp_s4->unk0E);
+        gDPPipeSync(temp_v0_2++);
+        gSPSegment(temp_v0_2++, 0x02, osVirtualToPhysical(arg0->unk00->unk00));
+        gSPDisplayList(temp_v0_2++, osVirtualToPhysical(temp_s4->unk3C->unk10));
+        gDPSetPrimColor(temp_v0_2++, 0, 0, arg1->r, arg1->g, arg1->b, arg1->a);
+        gDPPipeSync(temp_v0_2++);
+        gSPDisplayList(temp_v0_2++, osVirtualToPhysical(temp_s4->unk3C->unk14));
+        gDPPipeSync(temp_v0_2++);
+        gSPEndDisplayList(temp_v0_2++);
+    }
+    temp_s4->unk3C->unk00 = temp_s4->unk3C->unk04[D_800D2008_D2C08];
+    return temp_v0;
+}
+
+void func_8010CCD4_2C4144_tick_tock_hop(u16 arg0, Func_80055194_55D94_Struct* arg1, u16 arg2) {
+    HmfModelData_Struct* var_v1 = &HmfModelData[arg0];
+    HmfModelData_Unk64_Struct* temp_s2 = var_v1->unk64;
+    Gfx* temp_s0 = temp_s2->unk3C->unk04[D_800D2008_D2C08];
+
+    temp_s2->unk3C->unk00 = temp_s0;
+    gDPPipeSync(&temp_s0[0]);
+    gSPSegment(&temp_s0[1], 0x02, osVirtualToPhysical(arg1->unk00[arg2].unk00));
+    gSPDisplayList(&temp_s0[2], osVirtualToPhysical(temp_s2->unk3C->unk10));
+    gDPPipeSync(&temp_s0[3]);
+    gSPEndDisplayList(&temp_s0[4]);
+}
+
+void func_8010CDA4_2C4214_tick_tock_hop(u16 arg0, Func_80055194_55D94_Struct* arg1, u16 arg2, RGBA* arg3) {
+    HmfModelData_Struct* temp_hmf = &HmfModelData[arg0];
+    HmfModelData_Unk64_Struct* temp_s3 = temp_hmf->unk64;
+    HmfModelData_Unk64_Unk3C_Struct* temp_v1 = temp_s3->unk3C;
+    Gfx* temp_s0 = temp_v1->unk04[D_800D2008_D2C08];
+
+    temp_v1->unk00 = temp_s0;
+    gDPPipeSync(&temp_s0[0]);
+    gSPSegment(&temp_s0[1], 0x02, osVirtualToPhysical(arg1->unk00[arg2].unk00));
+    gSPDisplayList(&temp_s0[2], osVirtualToPhysical(temp_s3->unk3C->unk10));
+    gDPSetPrimColor(&temp_s0[3], 0, 0, arg3->r, arg3->g, arg3->b, arg3->a);
+    gDPPipeSync(&temp_s0[4]);
+    gSPDisplayList(&temp_s0[5], osVirtualToPhysical(temp_s3->unk3C->unk14));
+    gDPPipeSync(&temp_s0[6]);
+    gSPEndDisplayList(&temp_s0[7]);
+}
+
+s16 func_8010CED8_2C4348_tick_tock_hop(Func_80055194_55D94_Struct* arg0, HmfModelData_Unk64_Struct* arg1, f32 arg2, u16 arg3, u16 arg4) {
+    Vtx* temp_s7;
+    Vtx* var_s1;
+    Vtx_t* var_t0;
+    Vtx_t* var_a3;
+    s32 var_a2;
+    s32 temp_s4;
+    s32 temp_a1;
+    s32 sp24;
+    s32 temp_f2;
+    s32 var_s0;
+    s32 var_s2;
+    s32 sp2C;
+    s32 temp_lo;
+    s32 temp_s3;
+    s32 var_s0_2;
+    s32 var_a2_2;
+
+    if (arg0->unk1A >= 2) {
+        var_a2 = 0x800;
+    } else {
+        var_a2 = 0x1000;
+    }
+    temp_s4 = arg0->unk00->unk04;
+    temp_a1 = arg0->unk00->unk06;
+    sp24 = (f64) (temp_s4 * 0x64) * arg2 / 32.0;
+    temp_f2 = (f64) (temp_a1 * 0x64) * arg2 / 32.0;
+    if ((arg0->unk18 & 0xFFF) == 4) {
+        var_s0 = ((temp_s4 + 1) & 0xFFFE) * temp_a1 * 4;
+    } else {
+        var_s0 = temp_s4 * temp_a1 * arg0->unk18;
+    }
+    var_s0 = (var_s0 < 0) ? (var_s0 + 7) : var_s0;
+    var_s0 >>= 3;
+    var_s2 = var_s0 / var_a2;
+    if (var_s2 <= 0) {
+        var_s2 = 1;
+    }
+    sp2C = temp_a1 / var_s2;
+    temp_lo = temp_f2 / var_s2;
+    temp_s3 = var_s2 * 4;
+    temp_s7 = var_s1 = HuMemAllocTag(temp_s3 * sizeof(Vtx), arg1->unk0E);
+    memset(temp_s7, 0, temp_s3 * sizeof(Vtx));
+    for (var_s0_2 = 0; var_s0_2 < var_s2; var_s0_2++, var_s1 += 4) {
+        var_s1[0].v.ob[0] = (s32) (sp24 * 0.5);
+        var_s1[0].v.ob[1] = (s32) (temp_f2 * 0.5 - temp_lo * var_s0_2);
+        var_s1[0].v.tc[0] = (temp_s4 - 1) * 64;
+        var_s1[0].v.tc[1] = 0;
+        var_s1[1].v.ob[0] = (s32) (sp24 * 0.5);
+        var_s1[1].v.ob[1] = (s32) (temp_f2 * 0.5 - temp_lo * (var_s0_2 + 1));
+        var_s1[1].v.tc[0] = (temp_s4 - 1) * 64;
+        var_s1[1].v.tc[1] = (sp2C - 1) * 64;
+        var_s1[2].v.ob[0] = (s32) -(sp24 * 0.5);
+        var_s1[2].v.ob[1] = (s32) (temp_f2 * 0.5 - temp_lo * var_s0_2);
+        var_s1[2].v.tc[0] = 0;
+        var_s1[2].v.tc[1] = 0;
+        var_s1[3].v.ob[0] = (s32) -(sp24 * 0.5);
+        var_s1[3].v.ob[1] = (s32) (temp_f2 * 0.5 - temp_lo * (var_s0_2 + 1));
+        var_s1[3].v.tc[0] = 0;
+        var_s1[3].v.tc[1] = (sp2C - 1) * 64;
+        for (var_a2_2 = 0; var_a2_2 < 4; var_a2_2++) {
+            var_s1[var_a2_2].v.ob[0] += arg3;
+            var_s1[var_a2_2].v.ob[1] += arg4;
+            var_s1[var_a2_2].v.ob[2] = 0;
+            var_s1[var_a2_2].v.flag = 0;
+            var_s1[var_a2_2].v.cn[3] = 0xFF;
+            var_s1[var_a2_2].v.cn[0] = var_s1[var_a2_2].v.cn[1] = var_s1[var_a2_2].v.cn[2] = 0;
+        }
+    }
+    var_s1 = temp_s7;
+    for (var_s0_2 = 0; var_s0_2 < D_800D1FF0_D2BF0; var_s0_2++) {
+        arg1->unk44[var_s0_2] = HuMemAllocTag(temp_s3 * sizeof(Vtx), arg1->unk0E);
+        var_t0 = &arg1->unk44[var_s0_2]->v;
+        var_a3 = &var_s1->v;
+        for (var_a2_2 = 0; var_a2_2 < temp_s3; var_a2_2++) {
+            *(var_t0++) = *(var_a3++);
+        }
+    }
+    HuMemFree(temp_s7);
+    return var_s2;
+}
+
+void func_8010D2FC_2C476C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E700_2C5B70_tick_tock_hop = HuMemAllocTag(2 * sizeof(*D_8010E700_2C5B70_tick_tock_hop), 31000);
+    memset(D_8010E700_2C5B70_tick_tock_hop, 0, 2 * sizeof(*D_8010E700_2C5B70_tick_tock_hop));
+    arg1->unk40 = func_8010D5DC_2C4A4C_tick_tock_hop;
+}
+
+s32 func_8010D34C_2C47BC_tick_tock_hop(s16 arg0, D_8010E700_2C5B70_Unk60_Struct* arg1, f32 arg2, s16 arg3, s32 arg4) {
+    HmfModelData_Struct* temp_v1 = &HmfModelData[arg0];
+    D_8010E700_2C5B70_Struct* var_s0;
+    s16 var_s1;
+
+    var_s0 = D_8010E700_2C5B70_tick_tock_hop;
+    for (var_s1 = 0; var_s1 < 2; var_s1++, var_s0++) {
+        if (var_s0->unk04 == 0) {
+            var_s0->unk08 = &temp_v1->unk1C;
+            var_s0->unk0C = &temp_v1->unk20;
+            var_s0->unk10 = &temp_v1->unk24;
+            var_s0->unk14 = &temp_v1->unk28;
+            var_s0->unk18 = &temp_v1->unk2C;
+            var_s0->unk1C = &temp_v1->unk30;
+            var_s0->unk60 = *arg1;
+            var_s0->unk94 = arg2;
+            var_s0->unk90 = 4;
+            if (arg3 != 0) {
+                var_s0->unk98 = HuMemAllocTag(arg3 * 0x10, 0x7918);
+            }
+            var_s0->unk9C = arg3;
+            var_s0->unk9E = 0;
+            var_s0->unk00 = arg4;
+            var_s0->unk04 = 1;
+            break;
+        }
+    }
+    if (var_s1 == 2) {
+        return -1;
+    }
+    return var_s1;
+}
+
+D_8010E700_2C5B70_Unk98_Struct* func_8010D49C_2C490C_tick_tock_hop(s16 arg0, s16 arg1) {
+    D_8010E700_2C5B70_Unk98_Struct* temp_v0;
+    HmfModelData_Struct* var_v1;
+
+    if (arg0 >= 2) {
+        return NULL;
+    }
+    if (D_8010E700_2C5B70_tick_tock_hop[arg0].unk04 == 0) {
+        return NULL;
+    }
+    if (D_8010E700_2C5B70_tick_tock_hop[arg0].unk9E >= D_8010E700_2C5B70_tick_tock_hop[arg0].unk9C) {
+        return NULL;
+    }
+    temp_v0 = &D_8010E700_2C5B70_tick_tock_hop[arg0].unk98[D_8010E700_2C5B70_tick_tock_hop[arg0].unk9E];
+    var_v1 = &HmfModelData[arg1];
+    temp_v0->unk04 = &var_v1->unk1C;
+    temp_v0->unk08 = &var_v1->unk20;
+    temp_v0->unk0C = &var_v1->unk24;
+    D_8010E700_2C5B70_tick_tock_hop[arg0].unk9E++;
+    return temp_v0;
+}
+
+void func_8010D568_2C49D8_tick_tock_hop(s16 arg0, D_8010E700_2C5B70_Unk60_Struct* arg1, f32 arg2) {
+    D_8010E700_2C5B70_Struct* temp_s0;
+
+    if (arg0 < 2 && D_8010E700_2C5B70_tick_tock_hop[arg0].unk04 != 0) {
+        temp_s0 = &D_8010E700_2C5B70_tick_tock_hop[arg0];
+        memcpy(&temp_s0->unk60, arg1, temp_s0->unk90 * sizeof(Vec));
+        temp_s0->unk94 = arg2;
+    }
+}
+
+void func_8010D5DC_2C4A4C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1) {
+    D_8010E700_2C5B70_Struct* var_s2;
+    Vec sp20[4];
+    f32 temp_f0;
+    s32 temp_v1;
+    s16 var_s6;
+    s16 var_s3;
+    s16 var_s1;
+
+    var_s2 = D_8010E700_2C5B70_tick_tock_hop;
+    for (var_s6 = 0; var_s6 < 2; var_s6++, var_s2++) {
+        if (var_s2->unk04 == 0) {
+            continue;
+        }
+        if (var_s2->unk00 & 1) {
+            for (var_s3 = 0; var_s3 < var_s2->unk9E; var_s3++) {
+                var_s2->unk98[var_s3].unk00 = 0;
+            }
+            continue;
+        }
+        func_8010E2AC_2C571C_tick_tock_hop(*var_s2->unk08, *var_s2->unk0C, *var_s2->unk10, *var_s2->unk14, *var_s2->unk18, *var_s2->unk1C, var_s2->unk20);
+        func_8010E364_2C57D4_tick_tock_hop(var_s2->unk60.unk00, 4, var_s2->unk20, sp20);
+        for (var_s3 = 0; var_s3 < var_s2->unk9E; var_s3++) {
+            D_8010E700_2C5B70_Unk98_Struct* temp_s0_2 = &var_s2->unk98[var_s3];
+
+            if (!(var_s2->unk00 & 4) && *temp_s0_2->unk08 > var_s2->unk94) {
+                temp_s0_2->unk00 = 0;
+                continue;
+            }
+            temp_f0 = func_8010D938_2C4DA8_tick_tock_hop(var_s2, temp_s0_2, &sp20[D_8010E5E0_2C5A50_tick_tock_hop[0]], &sp20[D_8010E5E0_2C5A50_tick_tock_hop[1]]);
+            if (temp_f0 == 0.0f) {
+                temp_s0_2->unk00 = 0;
+                continue;
+            }
+            if (temp_f0 > 0.0f) {
+                temp_s0_2->unk00 = 1;
+                for (var_s1 = 1; var_s1 < 4; var_s1++) {
+                    temp_v1 = var_s1 * 3;
+                    temp_f0 = func_8010D938_2C4DA8_tick_tock_hop(var_s2, temp_s0_2, &sp20[D_8010E5E0_2C5A50_tick_tock_hop[temp_v1]], &sp20[D_8010E5E0_2C5A50_tick_tock_hop[temp_v1 + 1]]);
+                    if (temp_f0 == 0.0f) {
+                        temp_s0_2->unk00 = 1;
+                        break;
+                    }
+                    if (temp_f0 < 0.0f) {
+                        temp_s0_2->unk00 = 0;
+                        break;
+                    }
+                }
+            } else {
+                temp_s0_2->unk00 = 1;
+                for (var_s1 = 1; var_s1 < 4; var_s1++) {
+                    temp_v1 = var_s1 * 3;
+                    temp_f0 = func_8010D938_2C4DA8_tick_tock_hop(var_s2, temp_s0_2, &sp20[D_8010E5E0_2C5A50_tick_tock_hop[temp_v1]], &sp20[D_8010E5E0_2C5A50_tick_tock_hop[temp_v1 + 1]]);
+                    if (temp_f0 == 0.0f) {
+                        temp_s0_2->unk00 = 1;
+                        break;
+                    }
+                    if (temp_f0 > 0.0f) {
+                        temp_s0_2->unk00 = 0;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+// TODO: doesn't work with -Wa,--vr4300mul-off.
+f32 func_8010D938_2C4DA8_tick_tock_hop(D_8010E700_2C5B70_Struct* arg0, D_8010E700_2C5B70_Unk98_Struct* arg1, Vec* arg2, Vec* arg3) {
+    Vec sp0;
+    Vec sp10;
+    Vec sp20;
+
+    sp0.x = *arg1->unk04;
+    sp0.z = *arg1->unk0C;
+    sp10.x = arg2->x - sp0.x;
+    sp10.z = arg2->z - sp0.z;
+    sp20.x = arg3->x - sp0.x;
+    sp20.z = arg3->z - sp0.z;
+    return sp10.z * sp20.x - sp10.x * sp20.z;
+}
+
+s32 func_8010D99C_2C4E0C_tick_tock_hop(f32* arg0, u8* arg1, f32 arg2, f32 arg3, f32 arg4) {
+    f32 temp_div = *arg1 / arg4;
+
+    *arg0 = arg2 + (arg3 - arg2) * temp_div;
+    if (++(*arg1) > arg4) {
+        *arg1 = 0;
+        *arg0 = arg3;
+        return 1;
+    }
+    return 0;
+}
+
+f32 func_8010DA14_2C4E84_tick_tock_hop(f32 arg0, f32 arg1, f32 arg2, f32 arg3) {
+    if (arg0 > 1.0f) {
+        arg0 = 1.0f;
+    }
+    return (1.0f - arg0) * (1.0f - arg0) * arg1 + 2.0f * (1.0f - arg0) * arg0 * arg2 + arg0 * arg0 * arg3;
+}
+
+void func_8010DA80_2C4EF0_tick_tock_hop(s16* arg0, s16 arg1) {
+    s16 temp_id;
+    s16 temp_a1;
+    s16 var_s1;
+
+    for (var_s1 = 0; var_s1 < arg1; var_s1++) {
+        arg0[var_s1] = var_s1;
+    }
+    for (var_s1 = arg1 - 1; var_s1 >= 0; var_s1--) {
+        temp_id = rand16() % (var_s1 + 1);
+        temp_a1 = arg0[var_s1];
+        arg0[var_s1] = arg0[temp_id];
+        arg0[temp_id] = temp_a1;
+    }
+}
+
+void func_8010DB8C_2C4FFC_tick_tock_hop(omObjData* arg0) {
+    HmfModelData_Struct* temp_v0 = &HmfModelData[arg0->model[0]];
+
+    arg0->scale.x = temp_v0->unk34;
+    arg0->scale.y = temp_v0->unk38;
+    arg0->scale.z = temp_v0->unk3C;
+    arg0->trans.x = temp_v0->unk1C;
+    arg0->trans.y = temp_v0->unk20;
+    arg0->trans.z = temp_v0->unk24;
+    if (temp_v0->unk28 >= 360.0f) {
+        temp_v0->unk28 -= 360.0f;
+    }
+    if (temp_v0->unk28 < 0.0f) {
+        temp_v0->unk28 += 360.0f;
+    }
+    if (temp_v0->unk2C >= 360.0f) {
+        temp_v0->unk2C -= 360.0f;
+    }
+    if (temp_v0->unk2C < 0.0f) {
+        temp_v0->unk2C += 360.0f;
+    }
+    if (temp_v0->unk30 >= 360.0f) {
+        temp_v0->unk30 -= 360.0f;
+    }
+    if (temp_v0->unk30 < 0.0f) {
+        temp_v0->unk30 += 360.0f;
+    }
+    arg0->rot.x = temp_v0->unk28;
+    arg0->rot.y = temp_v0->unk2C;
+    arg0->rot.z = temp_v0->unk30;
+}
+
+// TODO: doesn't work with -Wa,--vr4300mul-off.
+void func_8010DD00_2C5170_tick_tock_hop(Vec arg0, Vec arg1, f32* arg2) {
+    Vec sp10;
+    f32 var_f2;
+    f32 temp_360 = 360.0f;
+
+    sp10.x = arg1.x - arg0.x;
+    sp10.y = arg1.y - arg0.y;
+    sp10.z = arg1.z - arg0.z;
+    var_f2 = func_8008E108_8ED08(sp10.y, sqrtf(sp10.x * sp10.x + sp10.z * sp10.z));
+    if (var_f2 < 0.0f) {
+        var_f2 += temp_360;
+    } else if (var_f2 >= temp_360) {
+        var_f2 -= temp_360;
+    }
+    *(arg2++) = var_f2;
+    var_f2 = func_8008E108_8ED08(sp10.x, sp10.z);
+    if (var_f2 < 0.0f) {
+        var_f2 += temp_360;
+    } else if (var_f2 >= temp_360) {
+        var_f2 -= temp_360;
+    }
+    *(arg2++) = var_f2;
+}
+
+void func_8010DE30_2C52A0_tick_tock_hop(f32* arg0, f32* arg1) {
+    f32 var_f2;
+
+    while (*arg1 < 0.0f) {
+        *arg1 += 360.0f;
+    }
+    while (*arg1 >= 360.0f) {
+        *arg1 -= 360.0f;
+    }
+    while (*arg0 < 0.0f) {
+        *arg0 += 360.0f;
+    }
+    while (*arg0 >= 360.0f) {
+        *arg0 -= 360.0f;
+    }
+    var_f2 = *arg1 - *arg0;
+    if (!(var_f2 > 0.0f)) {
+        var_f2 = -var_f2;
+    }
+    if (var_f2 > 180.0f) {
+        if (*arg0 < *arg1) {
+            *arg1 -= 360.0f;
+        } else {
+            *arg0 -= 360.0f;
+        }
+    }
+}
+
+void func_8010DFB0_2C5420_tick_tock_hop(f32* arg0) {
+    s16 i, j;
+
+    for (i = 0; i < 4; i++) {
+        for (j = 0; j < 4; j++) {
+            M_ID(arg0, i, j) = 0.0f;
+        }
+        M_ID(arg0, i, i) = 1.0f;
+    }
+}
+
+void func_8010E038_2C54A8_tick_tock_hop(f32* arg0, f32 arg1, f32 arg2, f32 arg3) {
+    func_8010DFB0_2C5420_tick_tock_hop(arg0);
+    M_ID(arg0, 3, 0) = arg1;
+    M_ID(arg0, 3, 1) = arg2;
+    M_ID(arg0, 3, 2) = arg3;
+}
+
+void func_8010E090_2C5500_tick_tock_hop(f32* arg0, f32 arg1) {
+    func_8010DFB0_2C5420_tick_tock_hop(arg0);
+    M_ID(arg0, 1, 1) = HuMathCos(arg1);
+    M_ID(arg0, 1, 2) = HuMathSin(arg1);
+    M_ID(arg0, 2, 1) = -HuMathSin(arg1);
+    M_ID(arg0, 2, 2) = HuMathCos(arg1);
+}
+
+void func_8010E0F8_2C5568_tick_tock_hop(f32* arg0, f32 arg1) {
+    func_8010DFB0_2C5420_tick_tock_hop(arg0);
+    M_ID(arg0, 0, 0) = HuMathCos(arg1);
+    M_ID(arg0, 0, 2) = -HuMathSin(arg1);
+    M_ID(arg0, 2, 0) = HuMathSin(arg1);
+    M_ID(arg0, 2, 2) = HuMathCos(arg1);
+}
+
+void func_8010E160_2C55D0_tick_tock_hop(f32* arg0, f32* arg1, f32* arg2) {
+    s16 i, j;
+
+    for (i = 0; i < 4; i++) {
+        for (j = 0; j < 4; j++) {
+            M_ID(arg2, i, j) = M_ID(arg0, i, 0) * M_ID(arg1, 0, j) + M_ID(arg0, i, 1) * M_ID(arg1, 1, j) + M_ID(arg0, i, 2) * M_ID(arg1, 2, j) + M_ID(arg0, i, 3) * M_ID(arg1, 3, j);
+        }
+    }
+}
+
+void func_8010E214_2C5684_tick_tock_hop(f32* arg0, f32* arg1) {
+    *(arg1++) = M_ID(arg0, 3, 0) * M_ID(arg0, 0, 0) + M_ID(arg0, 3, 1) * M_ID(arg0, 1, 0) + M_ID(arg0, 3, 2) * M_ID(arg0, 2, 0);
+    *(arg1++) = M_ID(arg0, 3, 0) * M_ID(arg0, 0, 1) + M_ID(arg0, 3, 1) * M_ID(arg0, 1, 1) + M_ID(arg0, 3, 2) * M_ID(arg0, 2, 1);
+    *(arg1++) = M_ID(arg0, 3, 0) * M_ID(arg0, 0, 2) + M_ID(arg0, 3, 1) * M_ID(arg0, 1, 2) + M_ID(arg0, 3, 2) * M_ID(arg0, 2, 2);
+}
+
+void func_8010E2AC_2C571C_tick_tock_hop(f32 arg0, f32 arg1, f32 arg2, f32 arg3, f32 arg4, f32 arg5, f32* arg6) {
+    f32 sp10[16];
+    f32 sp50[16];
+    f32 sp90[16];
+    f32 spD0[16];
+
+    func_8010E038_2C54A8_tick_tock_hop(sp10, arg0, arg1, arg2);
+    func_8010E090_2C5500_tick_tock_hop(sp50, arg3);
+    func_8010E0F8_2C5568_tick_tock_hop(sp90, arg4);
+    func_8010E160_2C55D0_tick_tock_hop(sp50, sp90, spD0);
+    func_8010E160_2C55D0_tick_tock_hop(spD0, sp10, arg6);
+}
+
+void func_8010E364_2C57D4_tick_tock_hop(Vec* arg0, s16 arg1, f32* arg2, Vec* arg3) {
+    s16 var_t0;
+
+    for (var_t0 = 0; var_t0 < arg1; var_t0++) {
+        arg3[var_t0].x = (M_ID(arg2, 3, 0) + arg0[var_t0].x) * M_ID(arg2, 0, 0) + (M_ID(arg2, 3, 1) + arg0[var_t0].y) * M_ID(arg2, 1, 0) + (M_ID(arg2, 3, 2) + arg0[var_t0].z) * M_ID(arg2, 2, 0);
+        arg3[var_t0].y = (M_ID(arg2, 3, 0) + arg0[var_t0].x) * M_ID(arg2, 0, 1) + (M_ID(arg2, 3, 1) + arg0[var_t0].y) * M_ID(arg2, 1, 1) + (M_ID(arg2, 3, 2) + arg0[var_t0].z) * M_ID(arg2, 2, 1);
+        arg3[var_t0].z = (M_ID(arg2, 3, 0) + arg0[var_t0].x) * M_ID(arg2, 0, 2) + (M_ID(arg2, 3, 1) + arg0[var_t0].y) * M_ID(arg2, 1, 2) + (M_ID(arg2, 3, 2) + arg0[var_t0].z) * M_ID(arg2, 2, 2);
+    }
+}

--- a/src/overlays/ovl_39_tick_tock_hop/ovl_39.h
+++ b/src/overlays/ovl_39_tick_tock_hop/ovl_39.h
@@ -1,0 +1,222 @@
+#ifndef _OVL_39_H
+#define _OVL_39_H
+
+#define SKIP_SPR_DECL
+#include "common.h"
+
+#define rand16() ((rand8() << 8) | rand8())
+
+// EXTERN
+
+typedef struct {
+    /* 0x00 */ Gfx* unk00;
+    /* 0x04 */ Gfx* unk04[3]; // unknown length
+    /* 0x10 */ void* unk10;
+    /* 0x14 */ void* unk14;
+} HmfModelData_Unk64_Unk3C_Struct; // Size unknown
+
+typedef struct {
+    /* 0x00 */ char unk00[0x50];
+    /* 0x50 */ s32 unk50;
+} HmfModelData_Unk64_Unk60_Struct; // Size unknown
+
+typedef struct {
+    /* 0x00 */ char unk00[8];
+    /* 0x08 */ s32 unk08;
+} HmfModelData_Unk64_Unk98_Struct; // Size unknown
+
+typedef struct {
+    /* 0x00 */ char unk00[0xE];
+    /* 0x0E */ s16 unk0E;
+    /* 0x10 */ char unk10[0x2C];
+    /* 0x3C */ HmfModelData_Unk64_Unk3C_Struct* unk3C;
+    /* 0x40 */ char unk40[4];
+    /* 0x44 */ Vtx* unk44[1]; // unknown length
+    /* 0x48 */ char unk48[0x18];
+    /* 0x60 */ HmfModelData_Unk64_Unk60_Struct* unk60;
+    /* 0x64 */ char unk64[0x34];
+    /* 0x98 */ HmfModelData_Unk64_Unk98_Struct* unk98;
+} HmfModelData_Unk64_Struct; // Size unknown
+
+typedef struct {
+    /* 0x00 */ char unk00[2];
+    /* 0x02 */ u8 unk02;
+    /* 0x03 */ char unk03[0x15];
+    /* 0x18 */ s32 unk18;
+    /* 0x1C */ f32 unk1C;
+    /* 0x20 */ f32 unk20;
+    /* 0x24 */ f32 unk24;
+    /* 0x28 */ f32 unk28;
+    /* 0x2C */ f32 unk2C;
+    /* 0x30 */ f32 unk30;
+    /* 0x34 */ f32 unk34;
+    /* 0x38 */ f32 unk38;
+    /* 0x3C */ f32 unk3C;
+    /* 0x40 */ f32 unk40;
+    /* 0x44 */ f32 unk44;
+    /* 0x48 */ char unk48[0x1C];
+    /* 0x64 */ HmfModelData_Unk64_Struct* unk64;
+    /* 0x68 */ char unk68[0xC];
+    /* 0x74 */ f32 unk74[16];
+    /* 0x78 */ char unkB4[0xC];
+} HmfModelData_Struct; // Size 0xC0
+
+typedef struct {
+    /* 0x00 */ char unk00[2];
+    /* 0x02 */ s16 unk02;
+    /* 0x04 */ char unk04[0x14];
+} D_800CCF58_CDB58_Struct; // Size 0x18
+
+extern HmfModelData_Struct* HmfModelData;
+extern D_800CCF58_CDB58_Struct* D_800CCF58_CDB58;
+
+// LOCAL
+
+typedef struct {
+    /* 0x00 */ u8 unk00;
+    /* 0x04 */ f32* unk04;
+    /* 0x08 */ f32* unk08;
+    /* 0x0C */ f32* unk0C;
+} D_8010E700_2C5B70_Unk98_Struct; // Size 0x10
+
+typedef struct {
+    /* 0x00 */ s16 unk00;
+    /* 0x02 */ s16 unk02;
+    /* 0x04 */ s32 unk04;
+    /* 0x08 */ s8 unk08;
+    /* 0x0A */ s16 unk0A;
+    /* 0x0C */ s16 unk0C;
+    /* 0x0E */ char unk0E[0x12];
+    /* 0x20 */ s16 unk20;
+    /* 0x22 */ s16 unk22;
+    /* 0x24 */ s16 unk24;
+    /* 0x26 */ char unk26[0x1A];
+    /* 0x40 */ D_8010E700_2C5B70_Unk98_Struct* unk40;
+    /* 0x44 */ D_8010E700_2C5B70_Unk98_Struct* unk44;
+    /* 0x48 */ f32 unk48;
+    /* 0x4C */ s16 unk4C;
+    /* 0x4E */ s16 unk4E;
+    /* 0x50 */ s16 unk50;
+    /* 0x52 */ s16 unk52;
+    /* 0x54 */ char unk54[8];
+} D_8010E6E4_2C5B54_Struct; // Size 0x5C
+
+typedef struct {
+    /* 0x00 */ omObjData* unk00;
+    /* 0x04 */ s16* unk04;
+    /* 0x08 */ s16 unk08;
+} D_8010E6F4_2C5B64_Unk00_Struct; // Size 0xC
+
+typedef struct d_8010E6F4_2C5B64_unk04_struct {
+    /* 0x00 */ s8 unk00;
+    /* 0x02 */ s16 unk02;
+    /* 0x04 */ s8 unk04;
+    /* 0x05 */ s8 unk05;
+    /* 0x06 */ char unk06[2];
+    /* 0x08 */ s32 unk08;
+    /* 0x0C */ s8 unk0C;
+    /* 0x0D */ s8 unk0D;
+    /* 0x0E */ s8 unk0E;
+    /* 0x0F */ char unk0F[1];
+    /* 0x10 */ s8 unk10;
+    /* 0x11 */ char unk11[0xB];
+    /* 0x1C */ s16 unk1C[2]; // unknown length
+    /* 0x20 */ char unk20[2];
+    /* 0x22 */ s16 unk22;
+    /* 0x24 */ s16 unk24;
+    /* 0x26 */ char unk26[6];
+    /* 0x2C */ f32 unk2C;
+    /* 0x30 */ f32 unk30;
+    /* 0x34 */ f32 unk34;
+    /* 0x38 */ f32 unk38;
+    /* 0x3C */ D_8010E6E4_2C5B54_Struct* unk3C;
+    /* 0x40 */ void (*unk40)(D_8010E6F4_2C5B64_Unk00_Struct*, struct d_8010E6F4_2C5B64_unk04_struct*);
+} D_8010E6F4_2C5B64_Unk04_Struct; // Size 0x44
+
+typedef struct {
+    /* 0x00 */ u32 unk00;
+    /* 0x04 */ s16 unk04;
+    /* 0x06 */ s16 unk06;
+    /* 0x08 */ s16 unk08;
+    /* 0x0A */ char unk0A[2];
+} D_8010E6F4_2C5B64_Unk0C_Struct; // Size 0xC
+
+typedef struct {
+    /* 0x00 */ D_8010E6F4_2C5B64_Unk00_Struct* unk00;
+    /* 0x04 */ D_8010E6F4_2C5B64_Unk04_Struct* unk04;
+    /* 0x08 */ s16 unk08;
+    /* 0x0C */ D_8010E6F4_2C5B64_Unk0C_Struct* unk0C;
+    /* 0x10 */ s8 unk10;
+} D_8010E6F4_2C5B64_Struct; // Size 0x14
+
+typedef struct {
+    /* 0x00 */ s8 unk00;
+    /* 0x01 */ u8 unk01;
+    /* 0x02 */ u8 unk02;
+    /* 0x04 */ u16 unk04;
+    /* 0x06 */ s16 unk06;
+} D_8010E6F8_2C5B68_Struct; // Size 8
+
+typedef struct {
+    /* 0x00 */ s8 unk00;
+    /* 0x04 */ s32 unk04;
+    /* 0x08 */ s8 unk08;
+    /* 0x0A */ s16 unk0A;
+    /* 0x0C */ f32 unk0C;
+    /* 0x10 */ f32 unk10;
+    /* 0x14 */ f32 unk14;
+} D_8010E6FC_2C5B6C_Struct; // Size 0x18
+
+typedef struct {
+    /* 0x00 */ Vec unk00[4];
+} D_8010E700_2C5B70_Unk60_Struct; // Size 0x30
+
+typedef struct {
+    /* 0x00 */ s32 unk00;
+    /* 0x04 */ s8 unk04;
+    /* 0x08 */ f32* unk08;
+    /* 0x0C */ f32* unk0C;
+    /* 0x10 */ f32* unk10;
+    /* 0x14 */ f32* unk14;
+    /* 0x18 */ f32* unk18;
+    /* 0x1C */ f32* unk1C;
+    /* 0x20 */ f32 unk20[16];
+    /* 0x60 */ D_8010E700_2C5B70_Unk60_Struct unk60;
+    /* 0x90 */ s16 unk90;
+    /* 0x94 */ f32 unk94;
+    /* 0x98 */ D_8010E700_2C5B70_Unk98_Struct* unk98;
+    /* 0x9C */ s16 unk9C;
+    /* 0x9E */ s16 unk9E;
+} D_8010E700_2C5B70_Struct; // Size 0xA0
+
+// 2C0E70
+void func_80109A00_2C0E70_tick_tock_hop(void);
+D_8010E6F4_2C5B64_Struct* func_80109A94_2C0F04_tick_tock_hop(omObjData* arg0, s8 arg1, s16 arg2, s16 arg3);
+s16 func_80109BE4_2C1054_tick_tock_hop(s8 arg0, s32 arg1, D_8010E6E4_2C5B54_Struct* arg2, void (*arg3)(D_8010E6F4_2C5B64_Unk00_Struct*, D_8010E6F4_2C5B64_Unk04_Struct*), s8 arg4);
+void func_80109CC0_2C1130_tick_tock_hop(s8 arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+void func_80109E2C_2C129C_tick_tock_hop(s8 arg0);
+s16 func_8010A07C_2C14EC_tick_tock_hop(u16 arg0, s32 arg1, s32 arg2, u16 arg3, s32 arg4);
+void func_8010A21C_2C168C_tick_tock_hop(s16 arg0, s32 arg1, s32 arg2);
+void func_8010A2B0_2C1720_tick_tock_hop(s16 arg0);
+void func_8010A300_2C1770_tick_tock_hop(void);
+s32 func_8010A3A8_2C1818_tick_tock_hop(s32 arg0, s32 arg1, f32 arg2, s32 arg3, s32 arg4);
+s32 func_8010A4A8_2C1918_tick_tock_hop(s16 arg0, f32 arg1, f32 arg2, f32 arg3, f32 arg4, f32 arg5, f32 arg6, f32 arg7, f32 arg8);
+void func_8010A620_2C1A90_tick_tock_hop(void);
+s32 func_8010A788_2C1BF8_tick_tock_hop(s32 arg0, s32 arg1, s32 arg2);
+void func_8010A9B0_2C1E20_tick_tock_hop(s16 arg0, f32* arg1, f32* arg2, f32* arg3);
+void func_8010ABCC_2C203C_tick_tock_hop(void);
+void func_8010D2FC_2C476C_tick_tock_hop(D_8010E6F4_2C5B64_Unk00_Struct* arg0, D_8010E6F4_2C5B64_Unk04_Struct* arg1);
+s32 func_8010D34C_2C47BC_tick_tock_hop(s16 arg0, D_8010E700_2C5B70_Unk60_Struct* arg1, f32 arg2, s16 arg3, s32 arg4);
+D_8010E700_2C5B70_Unk98_Struct* func_8010D49C_2C490C_tick_tock_hop(s16 arg0, s16 arg1);
+void func_8010D568_2C49D8_tick_tock_hop(s16 arg0, D_8010E700_2C5B70_Unk60_Struct* arg1, f32 arg2);
+void func_8010DA80_2C4EF0_tick_tock_hop(s16* arg0, s16 arg1);
+void func_8010DB8C_2C4FFC_tick_tock_hop(omObjData* arg0);
+void func_8010DD00_2C5170_tick_tock_hop(Vec arg0, Vec arg1, f32* arg2);
+void func_8010DE30_2C52A0_tick_tock_hop(f32* arg0, f32* arg1);
+
+extern D_8010E6F4_2C5B64_Struct* D_8010E6F4_2C5B64_tick_tock_hop;
+extern D_8010E6F8_2C5B68_Struct* D_8010E6F8_2C5B68_tick_tock_hop;
+extern D_8010E6FC_2C5B6C_Struct* D_8010E6FC_2C5B6C_tick_tock_hop;
+extern D_8010E700_2C5B70_Struct* D_8010E700_2C5B70_tick_tock_hop;
+
+#endif

--- a/symbol_addrs.txt
+++ b/symbol_addrs.txt
@@ -350,6 +350,8 @@ __checkHardware_msp = 0x8007F82C;
 send = 0x80080EF0;
 kdebugserver = 0x80081098;
 
+sqrtf = 0x80081240; //rom:0x81E40
+
 isPrintfInit = 0x80081320;
 is_proutSyncPrintf = 0x80081394;
 __checkHardware_isv = 0x80081580;
@@ -418,7 +420,7 @@ __rmonHitBreak = 0x800874A4;
 __rmonHitSpBreak = 0x80087580;
 __rmonHitCpuFault = 0x8008760C;
 rmonFindFaultedThreads = 0x80087638;
-sqrtf = 0x80087B10; //rom:0x88710
+
 sqrt = 0x80087B18; //rom:0x88718
 
 __osInitialize_autodetect = 0x8007F048;


### PR DESCRIPTION
BSS could not be linked. We're getting the following error when trying to use a BSS symbol:
> 'D_8010E6E8_2C5B58_tick_tock_hop' referenced in section '.text' of build/src/overlays/ovl_39_tick_tock_hop/2BCE10.c.o: defined in discarded section '.scommon' of build/src/overlays/ovl_39_tick_tock_hop/2BCE10.c.o